### PR TITLE
Update mui.F90

### DIFF
--- a/wrapper_f/mui.F90
+++ b/wrapper_f/mui.F90
@@ -5,7 +5,8 @@ module mui_3df
   interface
     subroutine mui_create_uniface3d_f(uniface,domain) bind(c)
       import :: c_ptr,c_char
-      type(c_ptr), intent(out), target :: uniface(*)
+    !type(c_ptr), intent(out), target :: uniface(*) !<- this line doesnt compile with ifort (error 8284)
+      type(c_ptr), intent(out), target :: uniface    !<- now yes!!
       character(kind=c_char), intent(in) :: domain(*)
     end subroutine mui_create_uniface3d_f
 


### PR DESCRIPTION
remove openmpi/1.8.1 (PATH, MANPATH, LD_LIBRARY_PATH)
load MKL/11.0.1 (LD_LIBRARY_PATH)
load PYTHON/2.7.3 (PATH, MANPATH, LD_LIBRARY_PATH, C_INCLUDE_PATH)
Set GNU compilers as MPI wrappers backend
load gcc/4.9.1 (PATH, MANPATH, LD_LIBRARY_PATH)
load openmpi/1.8.1 (PATH, MANPATH, LD_LIBRARY_PATH)
Generating F-wrapper object file...
mpic++ -std=c++11 -c mui_3df.cpp -o mui_3df.o -g -w 
Compiling unit test code...
mpif90  mui.F90 unit_test.f90 mui_3df.o  -o unit_test.x -g -lstdc++ -lmpi_cxx 
unit_test.f90(22): error #8284: If the actual argument is scalar, the dummy argument shall be scalar unless the actual argument is of type character or is an element of an array that is not assumed shape, pointer, or polymorphic.   [UNIFACE]
  call mui_create_uniface3d_f(uniface, trim(arg) )
-------^
compilation aborted for unit_test.f90 (code 1)
make: **\* [default] Error 1
