### PR TITLE
Replace broken (on macOS + clang) macros with endian-ness type traits

### DIFF
--- a/endian_traits.h
+++ b/endian_traits.h
@@ -1,0 +1,254 @@
+// -*- mode: C++; -*-
+//
+// Multiscale Universal Interface Code Coupling Library
+//
+// Copyright (C) 2018 R. W. Nash, The University of Edinburgh
+// 
+// This software is jointly licensed under the Apache License, Version
+// 2.0 and the GNU General Public License version 3, you may use it
+// according to either.
+// 
+// ** Apache License, version 2.0 **
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License.  You
+// may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+// 
+// ** GNU General Public License, version 3 **
+// 
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// ** File Details **
+//
+// Filename: endian_traits.h
+// Created: 2018-11-14
+// Author: R. W. Nash <r.nash@epcc.ed.ac.uk>
+// Description: Support for dealing with big and little endian platforms.
+// 
+// Currently this only supports big and little endian platforms, if
+// you're on something odder, then this wont work.
+//
+// The primary export of this header is a template struct
+// endian_traits - see below for a details
+// 
+// You can configure endianness and conversion by defining one of the following
+//
+//  1. no endian options, in which case this header will try to figure
+//     it out but that probably only works on GCC
+// 
+//  2. MUI_IGNORE_ENDIAN - this mode will never reorder the bytes of a
+//     multibyte number
+//
+//  3. (MUI_INT_BIG_ENDIAN ^ MUI_INT_LITTLE_ENDIAN) && (MUI_FLOAT_BIG_ENDIAN ^ MUI_FLOAT_LITTLE_ENDIAN)
+//
+//     where:
+//      - MUI_INT_BIG_ENDIAN - this will **assume** that the host has a big endian representation of integers
+//
+//      - MUI_INT_LITTLE_ENDIAN - this will **assume** that the host has a little endian representation of integers
+// 
+//      - MUI_FLOAT_BIG_ENDIAN - this will **assume** that the host has a big endian representation of floating values
+//
+//      - MUI_INT_LITTLE_ENDIAN - this will **assume** that the host has a little endian representation of floating values
+// 
+
+#ifndef MUI_ENDIAN_TRAITS_H_
+#define MUI_ENDIAN_TRAITS_H_
+
+#include <cstdint>
+
+#ifdef __APPLE__
+// MacOS does not provide <endian.h>
+// Provide mappings to MacOS specific function/macros 
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#else
+
+#include <endian.h>
+
+#endif
+
+// Convert input definitions (see above) to two macros returning bool
+// (MUI_CONVERT_FLOAT & MUI_CONVERT_INT) that tell the implementation
+// what to do
+#ifdef MUI_IGNORE_ENDIAN
+// Sanity check
+#  if defined(MUI_INT_BIG_ENDIAN) || defined(MUI_INT_LITTLE_ENDIAN) || defined(MUI_FLOAT_BIG_ENDIAN) || defined(MUI_FLOAT_LITTLE_ENDIAN)
+#    error "Must set no other MUI endian options with MUI_IGNORE_ENDIAN"
+#  endif
+
+// Never convert
+#  define MUI_CONVERT_INT false
+#  define MUI_CONVERT_FLOAT false
+
+#else // Not ignoring
+
+// Integers
+#  ifdef MUI_INT_BIG_ENDIAN
+#    ifdef MUI_INT_LITTLE_ENDIAN
+#      error "Both MUI_INT_BIG_ENDIAN and MUI_INT_LITTLE_ENDIAN defined!"
+#    else
+#      define MUI_CONVERT_INT false
+#    endif
+#  else
+#    ifdef MUI_INT_LITTLE_ENDIAN
+#      define MUI_CONVERT_INT true
+#    else
+// We have no endian options - try to figure it out.
+#      if defined(__BYTE_ORDER__)
+#        define MUI_CONVERT_INT (__BYTE_ORDER__ != __ORDER_BIG_ENDIAN__)
+#      else
+#        error "Cannot auto-detect integer endianness of platform - please set"
+#      endif
+#    endif
+#  endif
+
+// Floating points
+#  ifdef MUI_FLOAT_BIG_ENDIAN
+#    ifdef MUI_FLOAT_LITTLE_ENDIAN
+#      error "Both MUI_FLOAT_BIG_ENDIAN and MUI_FLOAT_LITTLE_ENDIAN defined!"
+#    else
+#      define MUI_CONVERT_FLOAT false
+#    endif
+#  else
+#    ifdef MUI_FLOAT_LITTLE_ENDIAN
+#      define MUI_CONVERT_FLOAT true
+#    else
+// We have no endian options - try to figure it out.
+#      if defined(__FLOAT_WORD_ORDER__)
+#        define MUI_CONVERT_FLOAT (__FLOAT_WORD_ORDER__ != __ORDER_BIG_ENDIAN__)
+#      else
+#        error "Cannot auto-detect float endianness of platform - please set"
+#      endif
+#    endif
+#  endif
+
+#endif // End definition processing
+
+namespace mui {
+  
+  namespace detail {
+    // Metafunction to get an unsigned integer type of the specified
+    // size in bytes as member type named "type".
+    template<size_t size_bytes>
+    struct uint;
+    // Specialisations for 8, 16, 32, 64 bits
+    template<>
+    struct uint<1> {
+      using type = uint8_t;
+    };   
+    template<>
+    struct uint<2> {
+      using type = uint16_t;
+    };
+    template<>
+    struct uint<4> {
+      using type = uint32_t;
+    };
+    template<>
+    struct uint<8> {
+      using type = uint64_t;
+    };
+    // Helper class to convert betweem host and big-endian
+    // (i.e. network) ordering using the htobe/betoh family of
+    // functions.
+    template<size_t size_bytes>
+    struct endian_converter {
+      union data_t {
+	char buf[size_bytes];
+	typename uint<size_bytes>::type val;
+      };
+      data_t data;
+      void htobe();
+      void betoh();
+    };
+    // Specialisations
+    template<>
+    void endian_converter<2>::htobe() {
+      data.val = htobe16(data.val);
+    }
+    template<>
+    void endian_converter<2>::betoh() {
+      data.val = be16toh(data.val);
+    }
+    template<>
+    void endian_converter<4>::htobe() {
+      data.val = htobe32(data.val);
+    }
+    template<>
+    void endian_converter<4>::betoh() {
+      data.val = be32toh(data.val);
+    }
+    template<>
+    void endian_converter<8>::htobe() {
+      data.val = htobe64(data.val);
+    }
+    template<>
+    void endian_converter<8>::betoh() {
+      data.val = be64toh(data.val);
+    }
+  }
+  
+  // Traits class for controlling MUI's behaviour about endianness.
+  //
+  // Uses SFINAE to select the appropriate specialisation based on the
+  // type.
+  // 
+  // It defines a bool constexpr member "convert" that indicates if
+  // the type should undergo byte reordering as it is (de-)serialised.
+  //
+  // Currently will handle integral (signed or unsigned, widths of 8,
+  // 16, 32, 64 b) and floating (32 or 64 b) types.
+  template<typename T, typename enable = void>
+  struct endian_traits;
+
+  // Integers
+  template<typename T>
+  struct endian_traits<T, typename std::enable_if<std::is_integral<T>::value>::type>
+  {
+    static constexpr bool convert = (sizeof(T) > 1) && MUI_CONVERT_INT;
+  };
+
+  // Floats
+  template<typename T>
+  struct endian_traits<T, typename std::enable_if<std::is_floating_point<T>::value>::type>
+  {
+    static constexpr bool convert = MUI_CONVERT_FLOAT;
+  };
+
+}
+
+#endif // Include guard

--- a/stream.h
+++ b/stream.h
@@ -50,6 +50,8 @@ Description:
 #include <memory>
 #include <algorithm>
 
+#include "endian_traits.h"
+
 namespace mui {
 
 class istream {
@@ -167,77 +169,50 @@ std::size_t streamed_size( const T& a, const Args&... args )
 	return stream.size() + streamed_size(args...);
 }
 
-#define Makeopsh(TYPE,T)						\
-	inline istream& operator>> ( istream& stream, TYPE& t )		\
-	{								\
-		stream.read(reinterpret_cast<char*>(&t),sizeof(t));	\
-		return stream;						\
-	}								\
-	inline ostream& operator<< ( ostream& stream, TYPE t )		\
-	{								\
-		stream.write(reinterpret_cast<char*>(&t),sizeof(t));	\
-		return stream;						\
-	}
+  // Use SFINAE to enable this only for types we marked as not
+  // requiring endian conversion
+  template<typename T,
+	   typename std::enable_if<endian_traits<T>::convert == false>::type* = nullptr>
+  istream& operator>>(istream& stream, T& dest) {
+    stream.read(reinterpret_cast<char*>(&dest), sizeof(T));
+    return stream;
+  }
 
-// use network-byte-order(big-endian)
-#define Makeopshs(TYPE,SZ)						\
-	inline istream& operator>> ( istream& stream, TYPE& t )		\
-	{								\
-		int##SZ##_t be;						\
-		stream.read(reinterpret_cast<char*>(&be),sizeof(be));	\
-		be = be##SZ##toh (be);					\
-		std::memcpy(reinterpret_cast<char*>(&t),		\
-		            reinterpret_cast<char*>(&be), sizeof(be));	\
-		return stream;						\
-	}								\
-	inline ostream& operator<< ( ostream& stream, TYPE t )		\
-	{								\
-		int##SZ##_t be;						\
-		std::memcpy(reinterpret_cast<char*>(&be),		\
-		            reinterpret_cast<char*>(&t), sizeof(be));	\
-		be = htobe##SZ (be);					\
-		stream.write(reinterpret_cast<char*>(&be),sizeof(be));	\
-		return stream;						\
-	}
+  // Use SFINAE to enable this only for types we marked as requiring
+  // endian conversion
+  template<typename T,
+	   typename std::enable_if<endian_traits<T>::convert == true>::type* = nullptr>
+  istream& operator>>(istream& stream, T& dest) {
+    detail::endian_converter<sizeof(T)> conv;
+    stream.read(conv.data.buf, sizeof(T));
+    conv.betoh();
+    std::memcpy(reinterpret_cast<char*>(&dest),
+		conv.data.buf, sizeof(T));
+    return stream;
+  }
 
-Makeopsh(char,8);
-Makeopsh(signed char,8);
-Makeopsh(unsigned char,8);
+  // Use SFINAE to enable this only for types we marked as not
+  // requiring endian conversion
+  template<typename T,
+	   typename std::enable_if<endian_traits<T>::convert == false>::type* = nullptr>
+  ostream& operator<<(ostream& stream, const T& src) {
+    stream.write(reinterpret_cast<const char*>(&src), sizeof(T));
+    return stream;
+  }
 
-#ifndef MUI_IGNORE_ENDIAN
-#if __BYTE_ORDER == __BIG_ENDIAN
-#  define Makeopshi Makeopsh
-#  if __FLOAT_WORD_ORDER == __BYTE_ORDER
-#    define Makeopshf Makeopsh
-#  else
-#    define Makeopshf Makeopshs
-#  endif
-#else
-#  define Makeopshi Makeopshs
-#  if __FLOAT_WORD_ORDER == __BYTE_ORDER
-#    define Makeopshf Makeopshs
-#  else
-#    define Makeopshf Makeopsh
-#  endif
-#endif
-#else
-#define Makeopshi Makeopsh
-#define Makeopshf Makeopsh
-#endif
+  // Use SFINAE to enable this only for types we marked as requiring
+  // endian conversion
+  template<typename T,
+	   typename std::enable_if<endian_traits<T>::convert == true>::type* = nullptr>
+  ostream& operator<<(ostream& stream, const T& src) {
+    detail::endian_converter<sizeof(T)> conv;
+    std::memcpy(conv.data.buf,
+		reinterpret_cast<const char*>(&src), sizeof(T));
+    conv.htobe();
+    stream.write(conv.data.buf, sizeof(T));
+    return stream;
+  }
 
-Makeopshi(int16_t,16);
-Makeopshi(uint16_t,16);
-Makeopshi(int32_t,32);
-Makeopshi(uint32_t,32);
-Makeopshi(int64_t,64);
-Makeopshi(uint64_t,64);
-Makeopshf(float,32);
-Makeopshf(double,64);
-
-#undef Makeopshf
-#undef Makeopshi
-#undef Makeopshs
-#undef Makeopsh
 
 template<typename F, typename S>
 istream& operator>> ( istream& stream, std::pair<F,S>& pair )


### PR DESCRIPTION
The MUI demos do not compile on mac OS with clang because the macros for generating the overload sets of `istream& operator>>(istream&, T&)` and `ostream& operator<<(ostream&, const T& )` do not include all the needed types `T`.

I have reimplemented this with some simple types traits for the endian conversions. The macros for controlling this are now a bit different but I've tried to document this in the source (in endian_traits.h)