### PR TITLE
Revert "fix type error in uniface::is_ready()"

### DIFF
--- a/uniface.h
+++ b/uniface.h
@@ -382,8 +382,8 @@ public:
 	}
 
 	bool is_ready( const std::string& attr, time_type t ) const {
-	        return  std::any_of(log.begin(), log.end(), [=](const auto& time_frame) {
-	                return time_frame.second.find(attr) != time_frame.second.end(); }) // return false for nonexisting attributes.
+	        return  std::any_of(log.begin(), log.end(), [=](const bin_frame_type& a) {
+	                return a.find(attr) != a.end(); }) // return false for random @attr.
 	            && std::all_of(peers.begin(), peers.end(), [=](const peer_state& p) {
 	                return (!p.is_sending(t,recv_span)) || (p.current_t() >= t || p.next_t() > t); });
 	}


### PR DESCRIPTION
Reverts MxUI/MUI#19

This fix, using an auto type, gives the following error when compiling with GCC 7.3.0:

"error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14" 

It probably isn't reasonable to demand that anything which uses MUI has to be compiled with c++14 standard (forced use of c++11 is still a bit controversial with some codes).

Is there another workaround for this which allows MUI to keep to the c++11 standard?

