### PR TITLE
Exact sampling bug fixes

### DIFF
--- a/bin.h
+++ b/bin.h
@@ -269,7 +269,8 @@ public:
 
 		if(h == 0.0){ // if h is still zero (only in the case of all dimensions being zero) then warn the user as this may be a problem
 			h = 1.0; // in this special case set h to 1 arbitrarily so bins work numerically
-			std::cerr << "MUI Warning [bin.h]: Bin support size fixed to 1.0, check interface dimensionality or problem decomposition." << std::endl;
+			if(val.size() > 1)
+				std::cerr << "MUI Warning [bin.h]: Bin support size fixed to 1.0, check interface dimensionality or problem decomposition." << std::endl;
 		}
 
 		std::size_t nn=1;

--- a/chrono_samplers/chrono_sampler_exact.h
+++ b/chrono_samplers/chrono_sampler_exact.h
@@ -58,8 +58,8 @@ public:
 	using REAL       = typename CONFIG::REAL;
 	using INT        = typename CONFIG::INT;
 	using time_type  = typename CONFIG::time_type;
-	
-	chrono_sampler_exact( time_type tol = time_type(std::numeric_limits<time_type>::epsilon()) ) {
+
+	chrono_sampler_exact( time_type tol = time_type(std::numeric_limits<time_type>::epsilon())*10.0 ) {
 		tolerance = tol;
 	}
 
@@ -78,8 +78,11 @@ public:
 	time_type get_lower_bound( time_type focus ) const {
 		return focus - tolerance;
 	}
+	time_type get_tolerance() const {
+		return tolerance;
+	}
 
-protected:
+private:
 	time_type tolerance;
 };
 

--- a/chrono_samplers/chrono_sampler_exact.h
+++ b/chrono_samplers/chrono_sampler_exact.h
@@ -59,7 +59,7 @@ public:
 	using INT        = typename CONFIG::INT;
 	using time_type  = typename CONFIG::time_type;
 
-	chrono_sampler_exact( time_type tol = time_type(std::numeric_limits<time_type>::epsilon())*10.0 ) {
+	chrono_sampler_exact( time_type tol = time_type(std::numeric_limits<time_type>::epsilon()*10.0) ) {
 		tolerance = tol;
 	}
 

--- a/chrono_samplers/chrono_sampler_exact.h
+++ b/chrono_samplers/chrono_sampler_exact.h
@@ -59,7 +59,7 @@ public:
 	using INT        = typename CONFIG::INT;
 	using time_type  = typename CONFIG::time_type;
 	
-	chrono_sampler_exact( time_type tol = time_type(0) ) {
+	chrono_sampler_exact( time_type tol = time_type(std::numeric_limits<time_type>::epsilon()) ) {
 		tolerance = tol;
 	}
 

--- a/chrono_samplers/chrono_sampler_gauss.h
+++ b/chrono_samplers/chrono_sampler_gauss.h
@@ -84,6 +84,9 @@ public:
 	time_type get_lower_bound( time_type focus ) const {
 		return focus - cutoff;
 	}
+	time_type tolerance() const {
+		return time_type(0);
+	}
 
 protected:
 	time_type cutoff;

--- a/chrono_samplers/chrono_sampler_mean.h
+++ b/chrono_samplers/chrono_sampler_mean.h
@@ -81,6 +81,9 @@ public:
 	time_type get_lower_bound( time_type focus ) const {
 		return focus - left;
 	}
+	time_type tolerance() const {
+		return time_type(0);
+	}	
 
 protected:
 	time_type left, right;

--- a/chrono_samplers/chrono_sampler_null.h
+++ b/chrono_samplers/chrono_sampler_null.h
@@ -73,6 +73,9 @@ public:
 	time_type get_lower_bound( time_type focus ) const {
 		// to do: return oldest time needed with regard to focus
 	}
+	time_type tolerance() const {
+		return time_type(0);
+	}
 };
 
 }

--- a/chrono_samplers/chrono_sampler_sum.h
+++ b/chrono_samplers/chrono_sampler_sum.h
@@ -80,6 +80,9 @@ public:
 	time_type get_lower_bound( time_type focus ) const {
 		return focus - left;
 	}
+	time_type tolerance() const {
+		return time_type(0);
+	}	
 
 protected:
 	time_type left, right;

--- a/comm.h
+++ b/comm.h
@@ -68,7 +68,7 @@ public:
 
 	// send message
 	void send( message msg, const std::vector<bool> &is_sending ) {
-		if( is_sending.size() == static_cast<size_t>(remote_size()) )
+		if( is_sending.size() == static_cast<unsigned>(remote_size()) )
 			return send_impl_(std::move(msg), is_sending);
 		else {
 			std::vector<bool> dest = is_sending;

--- a/mui.h
+++ b/mui.h
@@ -92,7 +92,7 @@ namespace mui {
 			static const bool DEBUG = false;\
 			using data_types = type_list<int32_t,int64_t,double,float,std::string>;\
 			using EXCEPTION = exception_segv;\
-			static const bool FIXEDPOINTS = true;\
+			static const bool FIXEDPOINTS = false;\
 		} mui_config_##SUFFIX;\
 		using uniface##SUFFIX = uniface<config_##SUFFIX>;\
 		using point##SUFFIX = point<config_##SUFFIX::REAL,config_##SUFFIX::D>;\

--- a/spatial_samplers/sampler_exact.h
+++ b/spatial_samplers/sampler_exact.h
@@ -80,8 +80,9 @@ public:
 		return OTYPE();
 	}
 	inline geometry::any_shape<CONFIG> support( point_type focus ) const {
-		//Set search radius at 10*epsilon to allow for rounding error but minimise problem set as far as possible as this is an exact sampler
-		return geometry::sphere<CONFIG>( focus, std::numeric_limits<REAL>::epsilon()*static_cast<REAL>(10.0) );
+		//Set search radius at 1000*epsilon to allow for rounding error while minimising problem set as far as possible.
+		//This may cause issues for very small or large domain sizes
+		return geometry::sphere<CONFIG>( focus, std::numeric_limits<REAL>::epsilon()*static_cast<REAL>(1000.0) );
 	}
 
 protected:

--- a/spatial_samplers/sampler_exact.h
+++ b/spatial_samplers/sampler_exact.h
@@ -63,7 +63,7 @@ public:
 	using INT        = typename CONFIG::INT;
 	using point_type = typename CONFIG::point_type;
 
-	sampler_exact( REAL tol = REAL(std::numeric_limits<REAL>::epsilon()) ) {
+	sampler_exact( REAL tol = REAL(std::numeric_limits<REAL>::epsilon())*static_cast<REAL>(10.0) ) {
 	        tolerance = tol;
 	}
 

--- a/spatial_storage.h
+++ b/spatial_storage.h
@@ -121,21 +121,11 @@ public:
 		if( data_.empty() ) 
 			return s.filter( f, virtual_container<typename SAMPLER::ITYPE,CONFIG>(vec(),std::vector<bool>()), addtional... );
 		if( !is_built() ) EXCEPTION(std::logic_error("spatial storage: query error. "
-		                                             "Bin was not built yet. Internal data was corrupsed."));
+		                                             "Bin was not built yet. Internal data was corrupted."));
 		const vec& st = storage_cast<const vec&>(data_);
 		return s.filter( f, virtual_container<typename SAMPLER::ITYPE,CONFIG>(st,bin_.query(reg)), addtional...);
 	}
-	/*template<typename REGION, typename FOCUS, typename SAMPLER>
-	typename SAMPLER::OTYPE 
-	query2(const REGION& reg, const FOCUS& f, const SAMPLER& s) const {
-		using vec = std::vector<std::pair<point_type,typename SAMPLER::ITYPE> >;
-		if( data_.empty() ) 
-			return s.filter(f, vec());
-		if( !is_built() ) EXCEPTION( std::logic_error("spatial storage: query error. "
-		                                               "not builded bin. Internal data was corrupsed.") );
-		const vec& st= storage_cast<const vec&>(data_);
-		return s.filter(f,bin_.query2(reg,st));
-	}*/
+
 	void build() {
 		if( is_built() ) EXCEPTION(std::logic_error("spatial storage: build error. cannot build twice."));
 		if( !data_.empty() ){
@@ -160,33 +150,10 @@ public:
 		else if( data_.which() == storage.which() ) data_.apply_visitor(insert_{storage});
 		else EXCEPTION(bad_storage_id("spatial storage: insert error. Type doesn't match."));
 	}
-	
-	template<typename SAMPLER, typename ... ADDITIONAL>
-    std::vector<point_type>
-    return_points(const SAMPLER& s, ADDITIONAL && ... additional) {
-        // this method is thread-safe. other methods are not.
-        {
-            std::unique_lock<std::mutex> lock(mutex_);
-            if( !is_built() ) build();
-        }
-
-        using vec = std::vector<std::pair<point_type,typename SAMPLER::ITYPE> >;
-
-        if( !is_built() ) EXCEPTION(std::logic_error("spatial storage: points query error. "
-                                                     "Bin not built yet. Internal data was corrupted."));
-        const vec& st = storage_cast<const vec&>(data_);
-
-        std::vector<point_type> returnPoints(st.size());
-
-        for( size_t i=0; i<st.size(); ++i ){
-          returnPoints[i] = st[i].first;
-        }
-
-        return returnPoints;
-    }
 
 	bool is_built() const { return is_bin_; }
 	bool empty() const { return data_.empty(); }
+	const storage_t& data() { return data_; }
 private:
 	void destroy_if_bin_() { 
 		if( is_built() ) {

--- a/uniface.h
+++ b/uniface.h
@@ -308,7 +308,7 @@ public:
 	fetch( const std::string& attr,const point_type focus, const time_type t,
 	       const SAMPLER& sampler, const TIME_SAMPLER &t_sampler,
 	       ADDITIONAL && ... additional ) {
-		barrier(t_sampler.get_upper_bound(t) - std::numeric_limits<time_type>::epsilon());
+		barrier(t_sampler.get_upper_bound(t) - t_sampler.get_tolerance());
 		std::vector<std::pair<time_type,typename SAMPLER::OTYPE> > v;
 
 		for( auto first=log.lower_bound(t_sampler.get_lower_bound(t)),
@@ -332,13 +332,15 @@ public:
 		return storage_cast<TYPE&>(n);
 	}
 
-	template<typename TYPE>
-	std::vector<point_type>
-	fetch_points( const std::string& attr, const time_type t ) {
-		barrier(t);
+	template<typename TYPE, class TIME_SAMPLER, typename ... ADDITIONAL>
+        std::vector<point_type>
+	fetch_points( const std::string& attr, const time_type t, const TIME_SAMPLER &t_sampler,
+               ADDITIONAL && ... additional ) {
+		barrier(t - t_sampler.get_tolerance());
 		std::vector <point_type> returnPoints;
 
-		for( auto first=log.lower_bound(t), last = log.upper_bound(t); first!= last; ++first ){
+		for( auto first=log.lower_bound(t_sampler.get_lower_bound(t)),
+		     last = log.upper_bound(t_sampler.get_upper_bound(t)); first!= last; ++first ){
 			auto iter = first->second.find(attr);
 			if( iter == first->second.end() ) continue;
 			const storage_t& n = iter->second.data();

--- a/uniface.h
+++ b/uniface.h
@@ -398,8 +398,9 @@ public:
 		auto start = std::chrono::system_clock::now();
 		for(;;) {    // barrier must be thread-safe because it is called in fetch()
 			std::lock_guard<std::mutex> lock(mutex);
+			time_type t_lower = t - time_type(std::numeric_limits<time_type>::epsilon())*10.0; //Allow for rounding error
 			if( std::all_of(peers.begin(), peers.end(), [=](const peer_state& p) { 
-				return (!p.is_sending(t,recv_span)) || (p.current_t() >= t || p.next_t() > t); }) ) break;
+				return (!p.is_sending(t,recv_span)) || (p.current_t() >= t_lower || p.next_t() > t_lower); }) ) break;
 			acquire(); // To avoid infinite-loop when synchronous communication
 		}
 		if( (std::chrono::system_clock::now() - start) > std::chrono::seconds(5) )


### PR DESCRIPTION
This integrates a number of fixes to improve the robustness of exact spatial and chrono sampling. It also adds the ability to "forget" a time-stamp in the main fetched log, as well as just the data.