### PR TITLE
Update the Python wrapper based on the recent changes of the MUI C++ code

### DIFF
--- a/wrappers/C/Makefile
+++ b/wrappers/C/Makefile
@@ -1,15 +1,16 @@
-default: mui_3d.cpp unit_test.c
+default: mui_3d.o
+	ar rcs libwrapperC.a mui_3d.o
+
+mui_3d.o: mui_3d.cpp unit_test.c
 	@echo "Generating C-wrapper object file..."
 	mpic++ -std=c++11 -c mui_3d.cpp -o mui_3d.o
-	@echo "Compiling unit test code..."
-	mpicc  -c unit_test.c -o unit_test.o
-	mpic++ unit_test.o mui_3d.o -o unit_test.x
+	@echo "Compiling and linking unit test code..."
+	mpicc  unit_test.c mui_3d.o -o unit_test.x -lstdc++ -lmpi_cxx -lmpi -lm
 	@echo "Launching unit test code..."
 	mpirun -np 1 ./unit_test.x mpi://domain1/interface : -np 1 ./unit_test.x mpi://domain2/interface
 	@echo "Usage: "
 	@echo "Step 1) include mui_3d.h in C source"
-	@echo "Step 2) Compile with a C compiler but do not link"
-	@echo "Step 3) Link with a C++ compiler the object code together with mui_3d.o"
+	@echo "Step 2) Compile with a C compiler & link"
 	
 clean:
-	rm *.o unit_test.x
+	rm *.o *.a unit_test.x

--- a/wrappers/C/mui_3d.cpp
+++ b/wrappers/C/mui_3d.cpp
@@ -55,6 +55,10 @@ typedef sampler_gauss3d<double>          mui_sampler_gauss3d;
 typedef sampler_moving_average3d<double> mui_sampler_moving_average3d;
 typedef chrono_sampler_exact3d           mui_chrono_sampler_exact3d;
 typedef chrono_sampler_mean3d            mui_chrono_sampler_mean3d;
+typedef sampler_exact3d<double>            mui_sampler_exact3d;
+typedef sampler_nearest_neighbor3d<double> mui_sampler_nearest3d;
+typedef sampler_pseudo_nearest_neighbor3d<double> mui_sampler_pseudo_nearest_neighbor3d;
+typedef sampler_pseudo_nearest2_linear3d<double> mui_sampler_pseudo_nearest2_linear3d;
 
 // allocator
 mui_uniface3d* mui_create_uniface3d( const char *URI ) {
@@ -67,6 +71,22 @@ mui_sampler_gauss3d* mui_create_sampler_3d( double r, double h ) {
 
 mui_sampler_moving_average3d* mui_create_sampler_moving_average3d( double dx, double dy, double dz ) {
 	return new mui_sampler_moving_average3d( point3d(dx,dy,dz) );
+}
+
+mui_sampler_exact3d* mui_create_sampler_exact3d() {
+    return new mui_sampler_exact3d();
+}
+
+mui_sampler_nearest3d* mui_create_sampler_nearest3d() {
+    return new mui_sampler_nearest3d();
+}
+
+mui_sampler_pseudo_nearest_neighbor3d* mui_create_sampler_pseudo_nearest_neighbor3d( double h ) {
+    return new mui_sampler_pseudo_nearest_neighbor3d( h );
+}
+
+mui_sampler_pseudo_nearest2_linear3d* mui_create_sampler_pseudo_nearest2_linear3d( double h ) {
+    return new mui_sampler_pseudo_nearest2_linear3d( h );
 }
 
 mui_chrono_sampler_exact3d* mui_create_chrono_sampler_exact3d() {
@@ -89,6 +109,17 @@ void mui_destroy_sampler_3d( mui_sampler_gauss3d* sampler ) {
 void mui_destroy_sampler_moving_average3d( mui_sampler_moving_average3d* sampler ) {
 	delete sampler;
 }
+void mui_destroy_sampler_nearest3d( mui_sampler_nearest3d* sampler ) {
+	delete sampler;
+}
+
+void mui_destroy_sampler_pseudo_nearest_neighbor3d( mui_sampler_pseudo_nearest_neighbor3d* sampler ) {
+	delete sampler;
+}
+
+void mui_destroy_sampler_pseudo_nearest2_linear3d( mui_sampler_pseudo_nearest2_linear3d* sampler ) {
+	delete sampler;
+}
 
 void mui_destroy_chrono_sampler_exact3d( mui_chrono_sampler_exact3d* sampler ) {
 	delete sampler;
@@ -106,6 +137,29 @@ void mui_push( mui_uniface3d* uniface, const char *attr, double x, double y, dou
 // spatial sampler: gaussian
 // temporal sampler: exact point
 double mui_fetch_gaussian_exact( mui_uniface3d* uniface, const char *attr, double x, double y, double z, double t, mui_sampler_gauss3d *spatial, mui_chrono_sampler_exact3d *temporal ) {
+	return uniface->fetch( std::string(attr), point3d(x,y,z), t, *spatial, *temporal );
+}
+// spatial sampler: exact
+// temporal sampler: exact point
+double mui_fetch_exact_exact( mui_uniface3d* uniface, const char *attr, double x, double y, double z, double t, mui_sampler_exact3d *spatial, mui_chrono_sampler_exact3d *temporal ) {
+	return uniface->fetch( std::string(attr), point3d(x,y,z), t, *spatial, *temporal );
+}
+
+// spatial sampler: nearest
+// temporal sampler: exact point
+double mui_fetch_nearest_exact( mui_uniface3d* uniface, const char *attr, double x, double y, double z, double t, mui_sampler_nearest3d *spatial, mui_chrono_sampler_exact3d *temporal ) {
+	return uniface->fetch( std::string(attr), point3d(x,y,z), t, *spatial, *temporal );
+}
+
+// spatial sampler: pseudo nearest
+// temporal sampler: exact point
+double mui_fetch_pseudo_nearest_exact( mui_uniface3d* uniface, const char *attr, double x, double y, double z, double t, mui_sampler_pseudo_nearest_neighbor3d *spatial, mui_chrono_sampler_exact3d *temporal ) {
+	return uniface->fetch( std::string(attr), point3d(x,y,z), t, *spatial, *temporal );
+}
+
+// spatial sampler: pseudo nearest2 linear
+// temporal sampler: exact point
+double mui_fetch_pseudo_nearest2_linear_exact( mui_uniface3d* uniface, const char *attr, double x, double y, double z, double t, mui_sampler_pseudo_nearest2_linear3d *spatial, mui_chrono_sampler_exact3d *temporal ) {
 	return uniface->fetch( std::string(attr), point3d(x,y,z), t, *spatial, *temporal );
 }
 
@@ -145,6 +199,11 @@ void mui_forget( mui_uniface3d* uniface, double first, double last ) {
 // set automatic deletion
 void mui_set_memory( mui_uniface3d* uniface, double length ) {
 	return uniface->set_memory( length );
+}
+
+// split comm
+MPI_Comm mui_mpi_split_by_app() {
+    return mpi_split_by_app();
 }
 
 }

--- a/wrappers/C/mui_3d.h
+++ b/wrappers/C/mui_3d.h
@@ -47,16 +47,27 @@ Description:
 #ifndef MUI_3D_H_
 #define MUI_3D_H_
 
+#include "mpi.h"
+
 typedef struct mui_uniface3d                mui_uniface3d;
 typedef struct mui_sampler_gauss3d          mui_sampler_gauss3d;
 typedef struct mui_sampler_moving_average3d mui_sampler_moving_average3d;
 typedef struct mui_chrono_sampler_exact3d   mui_chrono_sampler_exact3d;
 typedef struct mui_chrono_sampler_mean3d    mui_chrono_sampler_mean3d;
+typedef struct mui_sampler_exact3d          mui_sampler_exact3d;
+typedef struct mui_sampler_nearest3d        mui_sampler_nearest3d;
+typedef struct mui_sampler_pseudo_nearest_neighbor3d        mui_sampler_pseudo_nearest_neighbor3d;
+typedef struct mui_sampler_pseudo_nearest2_linear3d        mui_sampler_pseudo_nearest2_linear3d;
 
 /* allocator */
 mui_uniface3d* mui_create_uniface3d( const char *URI );
 mui_sampler_gauss3d* mui_create_sampler_3d( double r, double h );
 mui_sampler_moving_average3d* mui_create_sampler_moving_average3d( double dx, double dy, double dz );
+mui_sampler_exact3d* mui_create_sampler_exact3d();
+mui_sampler_nearest3d* mui_create_sampler_nearest3d();
+mui_sampler_pseudo_nearest_neighbor3d* mui_create_sampler_pseudo_nearest_neighbor3d();
+mui_sampler_pseudo_nearest2_linear3d* mui_create_sampler_pseudo_nearest2_linear3d();
+
 mui_chrono_sampler_exact3d* mui_create_chrono_sampler_exact3d();
 mui_chrono_sampler_mean3d* mui_create_chrono_sampler_mean3d( double past, double future );
 
@@ -64,6 +75,11 @@ mui_chrono_sampler_mean3d* mui_create_chrono_sampler_mean3d( double past, double
 void mui_destroy_uniface3d( mui_uniface3d *uniface );
 void mui_destroy_sampler_3d( mui_sampler_gauss3d* sampler );
 void mui_destroy_sampler_moving_average3d( mui_sampler_moving_average3d* sampler );
+void mui_destroy_sampler_exact3d( mui_sampler_exact3d* sampler );
+void mui_destroy_sampler_nearest3d( mui_sampler_nearest3d* sampler );
+void mui_destroy_sampler_pseudo_nearest_neighbor3d( mui_sampler_pseudo_nearest_neighbor3d* sampler );
+void mui_destroy_sampler_nearest2_linear3d( mui_sampler_pseudo_nearest2_linear3d* sampler );
+
 void mui_destroy_chrono_sampler_exact3d( mui_chrono_sampler_exact3d* sampler );
 void mui_destroy_chrono_sampler_mean3d( mui_chrono_sampler_mean3d* sampler );
 
@@ -73,6 +89,25 @@ void mui_push( mui_uniface3d* uniface, const char *attr, double x, double y, dou
 /*  spatial sampler: gaussian */
 /*  temporal sampler: exact point */
 double mui_fetch_gaussian_exact( mui_uniface3d* uniface, const char *attr, double x, double y, double z, double t, mui_sampler_gauss3d *spatial, mui_chrono_sampler_exact3d *temporal );
+
+/*  spatial sampler: exact */
+/*  temporal sampler: exact point */
+double mui_fetch_exact_exact( mui_uniface3d* uniface, const char *attr, double x, double y, double z, double t, mui_sampler_exact3d *spatial, mui_chrono_sampler_exact3d *temporal );
+
+/*  spatial sampler: nearest */
+/*  temporal sampler: exact point */
+double mui_fetch_nearest_exact( mui_uniface3d* uniface, const char *attr, double x, double y, double z, double t, mui_sampler_nearest3d *spatial, mui_chrono_sampler_exact3d *temporal );
+
+
+/*  spatial sampler: pseudo nearest */
+/*  temporal sampler: exact point */
+double mui_fetch_pseudo_nearest_exact( mui_uniface3d* uniface, const char *attr, double x, double y, double z, double t, mui_sampler_pseudo_nearest_neighbor3d *spatial, mui_chrono_sampler_exact3d *temporal );
+
+
+/*  spatial sampler: pseudo nearest2 linear */
+/*  temporal sampler: exact point */
+double mui_fetch_pseudo_nearest2_linear_exact( mui_uniface3d* uniface, const char *attr, double x, double y, double z, double t, mui_sampler_pseudo_nearest2_linear3d *spatial, mui_chrono_sampler_exact3d *temporal );
+
 
 /*  spatial sampler: gaussian */
 /*  temporal sampler: mean */
@@ -97,5 +132,8 @@ void mui_forget( mui_uniface3d*, double first, double last );
 
 /*  set automatic deletion */
 void mui_set_memory( mui_uniface3d*, double length );
+
+/*  split comm */
+MPI_Comm mui_mpi_split_by_app(void);
 
 #endif /* MUI_3D_H_ */

--- a/wrappers/Python/mui4py/mui4py.cpp
+++ b/wrappers/Python/mui4py/mui4py.cpp
@@ -83,10 +83,11 @@ using std::string;
 #define PUSH_INSTANCE_MANY(IO_TYPE)\
      .def("push_many_" STRINGIFY(IO_TYPE), (void (Tclass::*)(const string& attr, const py::array_t<Treal>& points, const py::array_t<IO_TYPE>& values)) &Tclass::push_many, "") 
 
-#define FETCH_POINTS_INSTANCE(IO_TYPE)\
+//Temporarily disabled the fetch_point function. Bind the variadic template later.
+//#define FETCH_POINTS_INSTANCE(IO_TYPE)\
     .def("fetch_points_" STRINGIFY(IO_TYPE), &Tclass::template fetch_points_np<IO_TYPE>) 
 
-#define DEFINE_MUI_UNIFACE_FETCH_POINTS() \
+//#define DEFINE_MUI_UNIFACE_FETCH_POINTS() \
     FOR_EACH(FETCH_POINTS_INSTANCE, double, float, int64_t, int32_t, string)
 
 #define FETCH_INSTANCE_1ARG(IO_TYPE) \
@@ -303,7 +304,8 @@ DECLARE_FUNC_HEADER(uniface) {
     DEFINE_MUI_UNIFACE_PUSH()
     DEFINE_MUI_UNIFACE_FETCH_1ARG()
     DEFINE_MUI_UNIFACE_FETCH_5ARGS()
-    DEFINE_MUI_UNIFACE_FETCH_POINTS()
+//Temporarily disabled the fetch_point function. Bind the variadic template later.
+//    DEFINE_MUI_UNIFACE_FETCH_POINTS()
     .def(py::init<const string &>());
     py::implicitly_convertible<mui::geometry::shape<Tconfig>, mui::geometry::any_shape<Tconfig>>();
 }

--- a/wrappers/Python/mui4py/mui4py.cpp
+++ b/wrappers/Python/mui4py/mui4py.cpp
@@ -293,8 +293,8 @@ DECLARE_FUNC_HEADER(uniface) {
     .def("forecast", (void (Tclass::*)(Ttime)) &Tclass::forecast, "")
     .def("is_ready", &Tclass::is_ready, "")
     .def("barrier", (void (Tclass::*)(Ttime)) &Tclass::barrier, "")
-    .def("forget", (void (Tclass::*)(Ttime)) &Tclass::forget, "")
-    .def("forget", (void (Tclass::*)(Ttime, Ttime)) &Tclass::forget, "")
+    .def("forget", (void (Tclass::*)(Ttime, bool)) &Tclass::forget, "")
+    .def("forget", (void (Tclass::*)(Ttime, Ttime, bool)) &Tclass::forget, "")
     .def("set_memory", (void (Tclass::*)(Ttime)) &Tclass::set_memory, "")
     .def("announce_send_span", (void (Tclass::*)(Ttime, Ttime, mui::geometry::any_shape<Tconfig>))\
            &Tclass::announce_send_span,"") 

--- a/wrappers/Python/mui4py/mui4py.py
+++ b/wrappers/Python/mui4py/mui4py.py
@@ -156,11 +156,6 @@ class Uniface(CppClass):
         assign  = getattr(self.raw, "assign_" + ALLOWED_IO_TYPES[data_type])
         assign(tag, safe_cast(data_type, val))
 
-    def push_size(self, tag, size, static_points):
-        data_type = map_type[self._get_tag_type(tag)]
-        push_size = getattr(self.raw, "push_size_" + ALLOWED_IO_TYPES[data_type])
-        push_size(tag, size, static_points)
-
     def announce_recv_span(self, tinit, timeout, geometry):
         assert issubclass(geometry.__class__, Geometry)
         geometry.configure(self.config)


### PR DESCRIPTION
Update the Python wrapper based on the recent changes of the MUI C++ code. It includes updated the 'forget' function, temporarily disabled the 'fetch_point' function and deleted the 'push_size' function. The C wrapper functions have also been updated (see git log for more details). 