### PR TITLE
More intuitive config types and bugfix

### DIFF
--- a/config.h
+++ b/config.h
@@ -63,7 +63,7 @@ struct one_dim {
 	using INT  = int;
 	using point_type = point<REAL,D>;
 	using time_type  = REAL; // INT-typed time stamp might be an alternative
-	using data_types = type_list<int,double,float>;
+	using data_types = type_list<int32_t,int64_t,double,float,std::string>;
 
 	static const bool DEBUG = false;
 	using EXCEPTION = exception_segv;
@@ -78,7 +78,7 @@ struct two_dim {
 	using INT  = int;
 	using point_type = point<REAL,D>;
 	using time_type  = REAL; // INT-typed time stamp might be an alternative
-	using data_types = type_list<int,double,float>;
+	using data_types = type_list<int32_t,int64_t,double,float,std::string>;
 
 	static const bool DEBUG = false;
 	using EXCEPTION = exception_segv;
@@ -93,7 +93,7 @@ struct three_dim {
 	using INT  = int;
 	using point_type = point<REAL,D>;
 	using time_type  = REAL; // INT-typed time stamp might be an alternative
-	using data_types = type_list<int,double,float>;
+	using data_types = type_list<int32_t,int64_t,double,float,std::string>;
 
 	static const bool DEBUG = false;
 	using EXCEPTION = exception_segv;

--- a/config.h
+++ b/config.h
@@ -56,7 +56,37 @@ namespace mui {
 
 template<typename... TYPES> struct type_list {};
 
-struct crunch {
+struct one_dim {
+	static const int D = 1;
+
+	using REAL = double;
+	using INT  = int;
+	using point_type = point<REAL,D>;
+	using time_type  = REAL; // INT-typed time stamp might be an alternative
+	using data_types = type_list<int,double,float>;
+
+	static const bool DEBUG = false;
+	using EXCEPTION = exception_segv;
+
+	static const bool FIXEDPOINTS = false;
+};
+
+struct two_dim {
+	static const int D = 2;
+
+	using REAL = double;
+	using INT  = int;
+	using point_type = point<REAL,D>;
+	using time_type  = REAL; // INT-typed time stamp might be an alternative
+	using data_types = type_list<int,double,float>;
+
+	static const bool DEBUG = false;
+	using EXCEPTION = exception_segv;
+
+	static const bool FIXEDPOINTS = false;
+};
+
+struct three_dim {
 	static const int D = 3;
 
 	using REAL = double;
@@ -72,7 +102,7 @@ struct crunch {
 };
 
 // backward-compatibility
-struct default_config : crunch {};
+struct default_config : three_dim {};
 
 /*
  * user can define his own config like this:

--- a/mui.h
+++ b/mui.h
@@ -93,7 +93,7 @@ namespace mui {
 			using REAL = REALTYPE;\
 			using INT  = INTTYPE;\
 			using point_type = point<REAL,D>;\
-			using time_type  = INT;\
+			using time_type  = REAL;\
 			static const bool DEBUG = false;\
 			using data_types = type_list<int32_t,int64_t,double,float,std::string>;\
 			using EXCEPTION = exception_segv;\
@@ -140,7 +140,7 @@ SPECIALIZE(3fx,float,int64_t,3);
 			using REAL = REALTYPE;\
 			using INT  = INTTYPE;\
 			using point_type = point<REAL,D>;\
-			using time_type  = INT;\
+			using time_type  = REAL;\
 			static const bool DEBUG = false;\
 			using data_types = type_list<int32_t,int64_t,double,float,std::string>;\
 			using EXCEPTION = exception_segv;\

--- a/spatial_samplers/sampler_exact.h
+++ b/spatial_samplers/sampler_exact.h
@@ -54,7 +54,7 @@
 
 namespace mui {
 
-template<typename CONFIG=default_config, typename O_TP=default_config::REAL, typename I_TP=O_TP>
+template<typename CONFIG=default_config, typename O_TP=typename CONFIG::REAL, typename I_TP=O_TP>
 class sampler_exact {
 public:
 	using OTYPE      = O_TP;
@@ -64,7 +64,7 @@ public:
 	using point_type = typename CONFIG::point_type;
 
 	sampler_exact( REAL tol = std::numeric_limits<REAL>::epsilon() ) {
-	    int exponent;
+	    INT exponent;
 		frexp10<REAL>( std::numeric_limits<REAL>::max(), exponent );
 		real_precision = static_cast<REAL>( exponent );
 		tolerance = tol;

--- a/spatial_samplers/sampler_gauss.h
+++ b/spatial_samplers/sampler_gauss.h
@@ -54,7 +54,7 @@
 
 namespace mui {
 
-template<typename CONFIG=default_config, typename O_TP=default_config::REAL, typename I_TP=O_TP>
+template<typename CONFIG=default_config, typename O_TP=typename CONFIG::REAL, typename I_TP=O_TP>
 class sampler_gauss {
 public:
 	using OTYPE      = O_TP;

--- a/spatial_samplers/sampler_mov_avg.h
+++ b/spatial_samplers/sampler_mov_avg.h
@@ -54,7 +54,7 @@
 
 namespace mui {
 
-template<typename CONFIG=default_config, typename O_TP=default_config::REAL, typename I_TP=O_TP>
+template<typename CONFIG=default_config, typename O_TP=typename CONFIG::REAL, typename I_TP=O_TP>
 class sampler_moving_average {
 public:
 	using OTYPE      = O_TP;

--- a/spatial_samplers/sampler_nn.h
+++ b/spatial_samplers/sampler_nn.h
@@ -53,7 +53,7 @@
 
 namespace mui {
 
-template<typename CONFIG=default_config, typename O_TP=default_config::REAL, typename I_TP=O_TP>
+template<typename CONFIG=default_config, typename O_TP=typename CONFIG::REAL, typename I_TP=O_TP>
 class sampler_nearest_neighbor {
 public:
 	using OTYPE      = O_TP;

--- a/spatial_samplers/sampler_null.h
+++ b/spatial_samplers/sampler_null.h
@@ -54,7 +54,7 @@
 
 namespace mui {
 
-template<typename CONFIG=default_config, typename O_TP=default_config::REAL, typename I_TP=O_TP>
+template<typename CONFIG=default_config, typename O_TP=typename CONFIG::REAL, typename I_TP=O_TP>
 class sampler_null {
 public:
 	using OTYPE      = O_TP;

--- a/spatial_samplers/sampler_pseudo_n2_linear.h
+++ b/spatial_samplers/sampler_pseudo_n2_linear.h
@@ -53,7 +53,7 @@
 
 namespace mui {
 
-template<typename CONFIG=default_config, typename O_TP=default_config::REAL, typename I_TP=O_TP>
+template<typename CONFIG=default_config, typename O_TP=typename CONFIG::REAL, typename I_TP=O_TP>
 class sampler_pseudo_nearest2_linear {
 public:
 	using OTYPE      = O_TP;

--- a/spatial_samplers/sampler_pseudo_nn.h
+++ b/spatial_samplers/sampler_pseudo_nn.h
@@ -53,7 +53,7 @@
 
 namespace mui {
 
-template<typename CONFIG=default_config, typename O_TP=default_config::REAL, typename I_TP=O_TP>
+template<typename CONFIG=default_config, typename O_TP=typename CONFIG::REAL, typename I_TP=O_TP>
 class sampler_pseudo_nearest_neighbor {
 public:
 	using OTYPE      = O_TP;

--- a/spatial_samplers/sampler_rbf.h
+++ b/spatial_samplers/sampler_rbf.h
@@ -54,7 +54,7 @@
 
 namespace mui {
 
-template<typename CONFIG=default_config, typename O_TP=default_config::REAL, typename I_TP=O_TP>
+template<typename CONFIG=default_config, typename O_TP=typename CONFIG::REAL, typename I_TP=O_TP>
 class sampler_rbf 
 {
 public:

--- a/spatial_samplers/sampler_shepard_quintic.h
+++ b/spatial_samplers/sampler_shepard_quintic.h
@@ -55,7 +55,7 @@
 namespace mui
 {
 
-template<typename CONFIG=default_config, typename O_TP=default_config::REAL, typename I_TP=O_TP>
+template<typename CONFIG=default_config, typename O_TP=typename CONFIG::REAL, typename I_TP=O_TP>
 class sampler_shepard_quintic
 {
 public:

--- a/spatial_samplers/sampler_sph_quintic.h
+++ b/spatial_samplers/sampler_sph_quintic.h
@@ -55,7 +55,7 @@
 namespace mui
 {
 
-template<typename CONFIG=default_config, typename O_TP=default_config::REAL, typename I_TP=O_TP>
+template<typename CONFIG=default_config, typename O_TP=typename CONFIG::REAL, typename I_TP=O_TP>
 class sampler_sph_quintic
 {
 public:

--- a/spatial_samplers/sampler_sum_quintic.h
+++ b/spatial_samplers/sampler_sum_quintic.h
@@ -55,7 +55,7 @@
 namespace mui
 {
 
-template<typename CONFIG=default_config, typename O_TP=default_config::REAL, typename I_TP=O_TP>
+template<typename CONFIG=default_config, typename O_TP=typename CONFIG::REAL, typename I_TP=O_TP>
 class sampler_sum_quintic
 {
 public:


### PR DESCRIPTION
Introduce more intuitive 1D/2D/3D config types (default=3D) and small bugfix in spatial sampler typenames