### PR TITLE
Updated wrappers on new Fixed Relaxation API and get L2 norm functions - Towards MUI v2.1

### DIFF
--- a/changelog
+++ b/changelog
@@ -5,6 +5,7 @@
 [21 August 2023, 2.0+]
   - Fixed bugs related to memory leak of Aitken coupling algorithm
   - Add residual calculation and output function on Fixed Relaxation coupling algorithm
+  - Updated wrappers on new Fixed Relaxation API and get L2 norm functions
 
 [01 August 2023, 2.0]
   - Refactor code base into new directory structure

--- a/wrappers/C/mui_c_wrapper_1d.cpp
+++ b/wrappers/C/mui_c_wrapper_1d.cpp
@@ -1221,8 +1221,92 @@ mui_algorithm_aitken_1t* mui_create_algorithm_aitken_1t(double under_relaxation_
 }
 
 /*******************************************
- * Aitken's functions for get info         *
+ * Algorithms functions for get info         *
  *******************************************/
+
+// Fixed relaxation algorithm get under relaxation factor functions
+float mui_fixed_relaxation_get_under_relaxation_factor_1f(mui_algorithm_fixed_relaxation_1f *fr, float t) {
+	return fr->get_under_relaxation_factor(t);
+}
+
+float mui_fixed_relaxation_get_under_relaxation_factor_1fx(mui_algorithm_fixed_relaxation_1fx *fr, float t) {
+	return fr->get_under_relaxation_factor(t);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_1d(mui_algorithm_fixed_relaxation_1d *fr, double t) {
+	return fr->get_under_relaxation_factor(t);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_1dx(mui_algorithm_fixed_relaxation_1dx *fr, double t) {
+	return fr->get_under_relaxation_factor(t);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_1t(mui_algorithm_fixed_relaxation_1t *fr, double t) {
+	return fr->get_under_relaxation_factor(static_cast<mui::mui_c_wrapper_1D::time_type>(t));
+}
+
+float mui_fixed_relaxation_get_under_relaxation_factor_1f_pair(mui_algorithm_fixed_relaxation_1f *fr, float t, float it) {
+	return fr->get_under_relaxation_factor(t, it);
+}
+
+float mui_fixed_relaxation_get_under_relaxation_factor_1fx_pair(mui_algorithm_fixed_relaxation_1fx *fr, float t, float it) {
+	return fr->get_under_relaxation_factor(t, it);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_1d_pair(mui_algorithm_fixed_relaxation_1d *fr, double t, double it) {
+	return fr->get_under_relaxation_factor(t, it);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_1dx_pair(mui_algorithm_fixed_relaxation_1dx *fr, double t, double it) {
+	return fr->get_under_relaxation_factor(t, it);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_1t_pair(mui_algorithm_fixed_relaxation_1t *fr, double t, double it) {
+	return fr->get_under_relaxation_factor(static_cast<mui::mui_c_wrapper_1D::time_type>(t),
+			static_cast<mui::mui_c_wrapper_1D::iterator_type>(it));
+}
+
+// Fixed relaxation algorithm get under relaxation factor functions
+float mui_fixed_relaxation_get_residual_L2_Norm_1f(mui_algorithm_fixed_relaxation_1f *fr, float t) {
+	return fr->get_residual_L2_Norm(t);
+}
+
+float mui_fixed_relaxation_get_residual_L2_Norm_1fx(mui_algorithm_fixed_relaxation_1fx *fr, float t) {
+	return fr->get_residual_L2_Norm(t);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_1d(mui_algorithm_fixed_relaxation_1d *fr, double t) {
+	return fr->get_residual_L2_Norm(t);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_1dx(mui_algorithm_fixed_relaxation_1dx *fr, double t) {
+	return fr->get_residual_L2_Norm(t);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_1t(mui_algorithm_fixed_relaxation_1t *fr, double t) {
+	return fr->get_residual_L2_Norm(static_cast<mui::mui_c_wrapper_1D::time_type>(t));
+}
+
+float mui_fixed_relaxation_get_residual_L2_Norm_1f_pair(mui_algorithm_fixed_relaxation_1f *fr, float t, float it) {
+	return fr->get_residual_L2_Norm(t, it);
+}
+
+float mui_fixed_relaxation_get_residual_L2_Norm_1fx_pair(mui_algorithm_fixed_relaxation_1fx *fr, float t, float it) {
+	return fr->get_residual_L2_Norm(t, it);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_1d_pair(mui_algorithm_fixed_relaxation_1d *fr, double t, double it) {
+	return fr->get_residual_L2_Norm(t, it);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_1dx_pair(mui_algorithm_fixed_relaxation_1dx *fr, double t, double it) {
+	return fr->get_residual_L2_Norm(t, it);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_1t_pair(mui_algorithm_fixed_relaxation_1t *fr, double t, double it) {
+	return fr->get_residual_L2_Norm(static_cast<mui::mui_c_wrapper_1D::time_type>(t),
+			static_cast<mui::mui_c_wrapper_1D::iterator_type>(it));
+}
 
 // Aitken's get under relaxation factor functions
 float mui_aitken_get_under_relaxation_factor_1f(mui_algorithm_aitken_1f *aitken, float t) {

--- a/wrappers/C/mui_c_wrapper_1d.cpp
+++ b/wrappers/C/mui_c_wrapper_1d.cpp
@@ -1039,7 +1039,7 @@ void mui_destroy_temporal_sampler_sum_1t(mui_temporal_sampler_sum_1t *sampler) {
  *******************************************/
 
 // Fixed relaxation algorithm
-mui_algorithm_fixed_relaxation_1f* mui_create_algorithm_fixed_relaxation_1f(float under_relaxation_factor = 1.0, mui_point_1f *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_1f* mui_create_algorithm_fixed_relaxation_1f(float under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_1f *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::point1f, float>> pts_value_init;
 
@@ -1054,10 +1054,10 @@ mui_algorithm_fixed_relaxation_1f* mui_create_algorithm_fixed_relaxation_1f(floa
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_1f(under_relaxation_factor, pts_value_init);
+	return new mui_algorithm_fixed_relaxation_1f(under_relaxation_factor, communicator, pts_value_init);
 }
 
-mui_algorithm_fixed_relaxation_1fx* mui_create_algorithm_fixed_relaxation_1fx(float under_relaxation_factor = 1.0, mui_point_1fx *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_1fx* mui_create_algorithm_fixed_relaxation_1fx(float under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_1fx *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::point1fx, float>> pts_value_init;
 
@@ -1072,10 +1072,10 @@ mui_algorithm_fixed_relaxation_1fx* mui_create_algorithm_fixed_relaxation_1fx(fl
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_1fx(under_relaxation_factor, pts_value_init);
+	return new mui_algorithm_fixed_relaxation_1fx(under_relaxation_factor, communicator, pts_value_init);
 }
 
-mui_algorithm_fixed_relaxation_1d* mui_create_algorithm_fixed_relaxation_1d(double under_relaxation_factor = 1.0, mui_point_1d *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_1d* mui_create_algorithm_fixed_relaxation_1d(double under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_1d *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::point1d, double>> pts_value_init;
 
@@ -1090,10 +1090,10 @@ mui_algorithm_fixed_relaxation_1d* mui_create_algorithm_fixed_relaxation_1d(doub
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_1d(under_relaxation_factor, pts_value_init);
+	return new mui_algorithm_fixed_relaxation_1d(under_relaxation_factor, communicator, pts_value_init);
 }
 
-mui_algorithm_fixed_relaxation_1dx* mui_create_algorithm_fixed_relaxation_1dx(double under_relaxation_factor = 1.0, mui_point_1dx *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_1dx* mui_create_algorithm_fixed_relaxation_1dx(double under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_1dx *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::point1dx, double>> pts_value_init;
 
@@ -1108,10 +1108,10 @@ mui_algorithm_fixed_relaxation_1dx* mui_create_algorithm_fixed_relaxation_1dx(do
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_1dx(under_relaxation_factor, pts_value_init);
+	return new mui_algorithm_fixed_relaxation_1dx(under_relaxation_factor, communicator, pts_value_init);
 }
 
-mui_algorithm_fixed_relaxation_1t* mui_create_algorithm_fixed_relaxation_1t(double under_relaxation_factor = 1.0, mui_point_1t *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_1t* mui_create_algorithm_fixed_relaxation_1t(double under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_1t *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::mui_c_wrapper_1D::point_type, mui::mui_c_wrapper_1D::REAL>> pts_value_init;
 
@@ -1126,7 +1126,7 @@ mui_algorithm_fixed_relaxation_1t* mui_create_algorithm_fixed_relaxation_1t(doub
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_1t(static_cast<mui::mui_c_wrapper_1D::REAL>(under_relaxation_factor), pts_value_init);
+	return new mui_algorithm_fixed_relaxation_1t(static_cast<mui::mui_c_wrapper_1D::REAL>(under_relaxation_factor), communicator, pts_value_init);
 }
 
 // Aitken's algorithm

--- a/wrappers/C/mui_c_wrapper_1d.h
+++ b/wrappers/C/mui_c_wrapper_1d.h
@@ -379,6 +379,28 @@ mui_algorithm_aitken_1dx* mui_create_algorithm_aitken_1dx(double under_relaxatio
 mui_algorithm_aitken_1t* mui_create_algorithm_aitken_1t(double under_relaxation_factor, double under_relaxation_factor_max,
 		MPI_Comm communicator, mui_point_1t *points, double *value_init, int pair_count, double res_l2_norm_nm1);
 
+// Fixed relaxation algorithms functions for get info
+float mui_fixed_relaxation_get_under_relaxation_factor_1f(mui_algorithm_fixed_relaxation_1f *fr, float t);
+float mui_fixed_relaxation_get_under_relaxation_factor_1fx(mui_algorithm_fixed_relaxation_1fx *fr, float t);
+double mui_fixed_relaxation_get_under_relaxation_factor_1d(mui_algorithm_fixed_relaxation_1d *fr, double t);
+double mui_fixed_relaxation_get_under_relaxation_factor_1dx(mui_algorithm_fixed_relaxation_1dx *fr, double t);
+double mui_fixed_relaxation_get_under_relaxation_factor_1t(mui_algorithm_fixed_relaxation_1t *fr, double t);
+float mui_fixed_relaxation_get_under_relaxation_factor_1f_pair(mui_algorithm_fixed_relaxation_1f *fr, float t, float it);
+float mui_fixed_relaxation_get_under_relaxation_factor_1fx_pair(mui_algorithm_fixed_relaxation_1fx *fr, float t, float it);
+double mui_fixed_relaxation_get_under_relaxation_factor_1d_pair(mui_algorithm_fixed_relaxation_1d *fr, double t, double it);
+double mui_fixed_relaxation_get_under_relaxation_factor_1dx_pair(mui_algorithm_fixed_relaxation_1dx *fr, double t, double it);
+double mui_fixed_relaxation_get_under_relaxation_factor_1t_pair(mui_algorithm_fixed_relaxation_1t *fr, double t, double it);
+float mui_fixed_relaxation_get_residual_L2_Norm_1f(mui_algorithm_fixed_relaxation_1f *fr, float t);
+float mui_fixed_relaxation_get_residual_L2_Norm_1fx(mui_algorithm_fixed_relaxation_1fx *fr, float t);
+double mui_fixed_relaxation_get_residual_L2_Norm_1d(mui_algorithm_fixed_relaxation_1d *fr, double t);
+double mui_fixed_relaxation_get_residual_L2_Norm_1dx(mui_algorithm_fixed_relaxation_1dx *fr, double t);
+double mui_fixed_relaxation_get_residual_L2_Norm_1t(mui_algorithm_fixed_relaxation_1t *fr, double t);
+float mui_fixed_relaxation_get_residual_L2_Norm_1f_pair(mui_algorithm_fixed_relaxation_1f *fr, float t, float it);
+float mui_fixed_relaxation_get_residual_L2_Norm_1fx_pair(mui_algorithm_fixed_relaxation_1fx *fr, float t, float it);
+double mui_fixed_relaxation_get_residual_L2_Norm_1d_pair(mui_algorithm_fixed_relaxation_1d *fr, double t, double it);
+double mui_fixed_relaxation_get_residual_L2_Norm_1dx_pair(mui_algorithm_fixed_relaxation_1dx *fr, double t, double it);
+double mui_fixed_relaxation_get_residual_L2_Norm_1t_pair(mui_algorithm_fixed_relaxation_1t *fr, double t, double it);
+
 // Aitken's algorithms functions for get info
 float mui_aitken_get_under_relaxation_factor_1f(mui_algorithm_aitken_1f *aitken, float t);
 float mui_aitken_get_under_relaxation_factor_1fx(mui_algorithm_aitken_1fx *aitken, float t);

--- a/wrappers/C/mui_c_wrapper_1d.h
+++ b/wrappers/C/mui_c_wrapper_1d.h
@@ -358,15 +358,15 @@ void mui_destroy_temporal_sampler_sum_1dx(mui_temporal_sampler_sum_1dx *sampler)
 void mui_destroy_temporal_sampler_sum_1t(mui_temporal_sampler_sum_1t *sampler);
 
 // MUI algorithms creation
-mui_algorithm_fixed_relaxation_1f* mui_create_algorithm_fixed_relaxation_1f(float under_relaxation_factor, mui_point_1f *points,
+mui_algorithm_fixed_relaxation_1f* mui_create_algorithm_fixed_relaxation_1f(float under_relaxation_factor, MPI_Comm communicator, mui_point_1f *points,
 		float *value_init, int pair_count);
-mui_algorithm_fixed_relaxation_1fx* mui_create_algorithm_fixed_relaxation_1fx(float under_relaxation_factor, mui_point_1fx *points,
+mui_algorithm_fixed_relaxation_1fx* mui_create_algorithm_fixed_relaxation_1fx(float under_relaxation_factor, MPI_Comm communicator, mui_point_1fx *points,
 		float *value_init, int pair_count);
-mui_algorithm_fixed_relaxation_1d* mui_create_algorithm_fixed_relaxation_1d(double under_relaxation_factor, mui_point_1d *points,
+mui_algorithm_fixed_relaxation_1d* mui_create_algorithm_fixed_relaxation_1d(double under_relaxation_factor, MPI_Comm communicator, mui_point_1d *points,
 		double *value_init, int pair_count);
-mui_algorithm_fixed_relaxation_1dx* mui_create_algorithm_fixed_relaxation_1dx(double under_relaxation_factor, mui_point_1dx *points,
+mui_algorithm_fixed_relaxation_1dx* mui_create_algorithm_fixed_relaxation_1dx(double under_relaxation_factor, MPI_Comm communicator, mui_point_1dx *points,
 		double *value_init, int pair_count);
-mui_algorithm_fixed_relaxation_1t* mui_create_algorithm_fixed_relaxation_1t(double under_relaxation_factor, mui_point_1t *points,
+mui_algorithm_fixed_relaxation_1t* mui_create_algorithm_fixed_relaxation_1t(double under_relaxation_factor, MPI_Comm communicator, mui_point_1t *points,
 		double *value_init, int pair_count);
 mui_algorithm_aitken_1f* mui_create_algorithm_aitken_1f(float under_relaxation_factor, float under_relaxation_factor_max,
 		MPI_Comm communicator, mui_point_1f *points, float *value_init, int pair_count, float res_l2_norm_nm1);

--- a/wrappers/C/mui_c_wrapper_2d.cpp
+++ b/wrappers/C/mui_c_wrapper_2d.cpp
@@ -1241,8 +1241,92 @@ mui_algorithm_aitken_2t* mui_create_algorithm_aitken_2t(double under_relaxation_
 }
 
 /*******************************************
- * Aitken's functions for get info         *
+ * Algorithms functions for get info         *
  *******************************************/
+
+// Fixed relaxation get under relaxation factor functions
+float mui_fixed_relaxation_get_under_relaxation_factor_2f(mui_algorithm_fixed_relaxation_2f *fr, float t) {
+	return fr->get_under_relaxation_factor(t);
+}
+
+float mui_fixed_relaxation_get_under_relaxation_factor_2fx(mui_algorithm_fixed_relaxation_2fx *fr, float t) {
+	return fr->get_under_relaxation_factor(t);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_2d(mui_algorithm_fixed_relaxation_2d *fr, double t) {
+	return fr->get_under_relaxation_factor(t);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_2dx(mui_algorithm_fixed_relaxation_2dx *fr, double t) {
+	return fr->get_under_relaxation_factor(t);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_2t(mui_algorithm_fixed_relaxation_2t *fr, double t) {
+	return fr->get_under_relaxation_factor(static_cast<mui::mui_c_wrapper_2D::time_type>(t));
+}
+
+float mui_fixed_relaxation_get_under_relaxation_factor_2f_pair(mui_algorithm_fixed_relaxation_2f *fr, float t, float it) {
+	return fr->get_under_relaxation_factor(t, it);
+}
+
+float mui_fixed_relaxation_get_under_relaxation_factor_2fx_pair(mui_algorithm_fixed_relaxation_2fx *fr, float t, float it) {
+	return fr->get_under_relaxation_factor(t, it);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_2d_pair(mui_algorithm_fixed_relaxation_2d *fr, double t, double it) {
+	return fr->get_under_relaxation_factor(t, it);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_2dx_pair(mui_algorithm_fixed_relaxation_2dx *fr, double t, double it) {
+	return fr->get_under_relaxation_factor(t, it);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_2t_pair(mui_algorithm_fixed_relaxation_2t *fr, double t, double it) {
+	return fr->get_under_relaxation_factor(static_cast<mui::mui_c_wrapper_2D::time_type>(t),
+			static_cast<mui::mui_c_wrapper_2D::iterator_type>(it));
+}
+
+// Fixed relaxation get under relaxation factor functions
+float mui_fixed_relaxation_get_residual_L2_Norm_2f(mui_algorithm_fixed_relaxation_2f *fr, float t) {
+	return fr->get_residual_L2_Norm(t);
+}
+
+float mui_fixed_relaxation_get_residual_L2_Norm_2fx(mui_algorithm_fixed_relaxation_2fx *fr, float t) {
+	return fr->get_residual_L2_Norm(t);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_2d(mui_algorithm_fixed_relaxation_2d *fr, double t) {
+	return fr->get_residual_L2_Norm(t);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_2dx(mui_algorithm_fixed_relaxation_2dx *fr, double t) {
+	return fr->get_residual_L2_Norm(t);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_2t(mui_algorithm_fixed_relaxation_2t *fr, double t) {
+	return fr->get_residual_L2_Norm(static_cast<mui::mui_c_wrapper_2D::time_type>(t));
+}
+
+float mui_fixed_relaxation_get_residual_L2_Norm_2f_pair(mui_algorithm_fixed_relaxation_2f *fr, float t, float it) {
+	return fr->get_residual_L2_Norm(t, it);
+}
+
+float mui_fixed_relaxation_get_residual_L2_Norm_2fx_pair(mui_algorithm_fixed_relaxation_2fx *fr, float t, float it) {
+	return fr->get_residual_L2_Norm(t, it);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_2d_pair(mui_algorithm_fixed_relaxation_2d *fr, double t, double it) {
+	return fr->get_residual_L2_Norm(t, it);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_2dx_pair(mui_algorithm_fixed_relaxation_2dx *fr, double t, double it) {
+	return fr->get_residual_L2_Norm(t, it);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_2t_pair(mui_algorithm_fixed_relaxation_2t *fr, double t, double it) {
+	return fr->get_residual_L2_Norm(static_cast<mui::mui_c_wrapper_2D::time_type>(t),
+			static_cast<mui::mui_c_wrapper_2D::iterator_type>(it));
+}
 
 // Aitken's get under relaxation factor functions
 float mui_aitken_get_under_relaxation_factor_2f(mui_algorithm_aitken_2f *aitken, float t) {

--- a/wrappers/C/mui_c_wrapper_2d.cpp
+++ b/wrappers/C/mui_c_wrapper_2d.cpp
@@ -1049,7 +1049,7 @@ void mui_destroy_temporal_sampler_sum_2t(mui_temporal_sampler_sum_2t *sampler) {
  *******************************************/
 
 // Fixed relaxation algorithm
-mui_algorithm_fixed_relaxation_2f* mui_create_algorithm_fixed_relaxation_2f(float under_relaxation_factor = 1.0, mui_point_2f *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_2f* mui_create_algorithm_fixed_relaxation_2f(float under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_2f *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::point2f, float>> pts_value_init;
 
@@ -1065,10 +1065,10 @@ mui_algorithm_fixed_relaxation_2f* mui_create_algorithm_fixed_relaxation_2f(floa
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_2f(under_relaxation_factor, pts_value_init);
+	return new mui_algorithm_fixed_relaxation_2f(under_relaxation_factor, communicator, pts_value_init);
 }
 
-mui_algorithm_fixed_relaxation_2fx* mui_create_algorithm_fixed_relaxation_2fx(float under_relaxation_factor = 1.0, mui_point_2fx *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_2fx* mui_create_algorithm_fixed_relaxation_2fx(float under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_2fx *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::point2fx, float>> pts_value_init;
 
@@ -1084,10 +1084,10 @@ mui_algorithm_fixed_relaxation_2fx* mui_create_algorithm_fixed_relaxation_2fx(fl
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_2fx(under_relaxation_factor, pts_value_init);
+	return new mui_algorithm_fixed_relaxation_2fx(under_relaxation_factor, communicator, pts_value_init);
 }
 
-mui_algorithm_fixed_relaxation_2d* mui_create_algorithm_fixed_relaxation_2d(double under_relaxation_factor = 1.0, mui_point_2d *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_2d* mui_create_algorithm_fixed_relaxation_2d(double under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_2d *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::point2d, double>> pts_value_init;
 
@@ -1103,10 +1103,10 @@ mui_algorithm_fixed_relaxation_2d* mui_create_algorithm_fixed_relaxation_2d(doub
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_2d(under_relaxation_factor, pts_value_init);
+	return new mui_algorithm_fixed_relaxation_2d(under_relaxation_factor, communicator, pts_value_init);
 }
 
-mui_algorithm_fixed_relaxation_2dx* mui_create_algorithm_fixed_relaxation_2dx(double under_relaxation_factor = 1.0, mui_point_2dx *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_2dx* mui_create_algorithm_fixed_relaxation_2dx(double under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_2dx *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::point2dx, double>> pts_value_init;
 
@@ -1122,10 +1122,10 @@ mui_algorithm_fixed_relaxation_2dx* mui_create_algorithm_fixed_relaxation_2dx(do
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_2dx(under_relaxation_factor, pts_value_init);
+	return new mui_algorithm_fixed_relaxation_2dx(under_relaxation_factor, communicator, pts_value_init);
 }
 
-mui_algorithm_fixed_relaxation_2t* mui_create_algorithm_fixed_relaxation_2t(double under_relaxation_factor = 1.0, mui_point_2t *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_2t* mui_create_algorithm_fixed_relaxation_2t(double under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_2t *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::mui_c_wrapper_2D::point_type, mui::mui_c_wrapper_2D::REAL>> pts_value_init;
 
@@ -1141,7 +1141,7 @@ mui_algorithm_fixed_relaxation_2t* mui_create_algorithm_fixed_relaxation_2t(doub
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_2t(static_cast<mui::mui_c_wrapper_2D::REAL>(under_relaxation_factor), pts_value_init);
+	return new mui_algorithm_fixed_relaxation_2t(static_cast<mui::mui_c_wrapper_2D::REAL>(under_relaxation_factor), communicator, pts_value_init);
 }
 
 // Aitken's algorithm

--- a/wrappers/C/mui_c_wrapper_2d.h
+++ b/wrappers/C/mui_c_wrapper_2d.h
@@ -384,6 +384,28 @@ mui_algorithm_aitken_2dx* mui_create_algorithm_aitken_2dx(double under_relaxatio
 mui_algorithm_aitken_2t* mui_create_algorithm_aitken_2t(double under_relaxation_factor, double under_relaxation_factor_max,
 		MPI_Comm communicator, mui_point_2t *points, double *value_init, int pair_count, double res_l2_norm_nm1);
 
+// Fixed relaxation algorithms functions for get info
+float mui_fixed_relaxation_get_under_relaxation_factor_2f(mui_algorithm_fixed_relaxation_2f *fr, float t);
+float mui_fixed_relaxation_get_under_relaxation_factor_2fx(mui_algorithm_fixed_relaxation_2fx *fr, float t);
+double mui_fixed_relaxation_get_under_relaxation_factor_2d(mui_algorithm_fixed_relaxation_2d *fr, double t);
+double mui_fixed_relaxation_get_under_relaxation_factor_2dx(mui_algorithm_fixed_relaxation_2dx *fr, double t);
+double mui_fixed_relaxation_get_under_relaxation_factor_2t(mui_algorithm_fixed_relaxation_2t *fr, double t);
+float mui_fixed_relaxation_get_under_relaxation_factor_2f_pair(mui_algorithm_fixed_relaxation_2f *fr, float t, float it);
+float mui_fixed_relaxation_get_under_relaxation_factor_2fx_pair(mui_algorithm_fixed_relaxation_2fx *fr, float t, float it);
+double mui_fixed_relaxation_get_under_relaxation_factor_2d_pair(mui_algorithm_fixed_relaxation_2d *fr, double t, double it);
+double mui_fixed_relaxation_get_under_relaxation_factor_2dx_pair(mui_algorithm_fixed_relaxation_2dx *fr, double t, double it);
+double mui_fixed_relaxation_get_under_relaxation_factor_2t_pair(mui_algorithm_fixed_relaxation_2t *fr, double t, double it);
+float mui_fixed_relaxation_get_residual_L2_Norm_2f(mui_algorithm_fixed_relaxation_2f *fr, float t);
+float mui_fixed_relaxation_get_residual_L2_Norm_2fx(mui_algorithm_fixed_relaxation_2fx *fr, float t);
+double mui_fixed_relaxation_get_residual_L2_Norm_2d(mui_algorithm_fixed_relaxation_2d *fr, double t);
+double mui_fixed_relaxation_get_residual_L2_Norm_2dx(mui_algorithm_fixed_relaxation_2dx *fr, double t);
+double mui_fixed_relaxation_get_residual_L2_Norm_2t(mui_algorithm_fixed_relaxation_2t *fr, double t);
+float mui_fixed_relaxation_get_residual_L2_Norm_2f_pair(mui_algorithm_fixed_relaxation_2f *fr, float t, float it);
+float mui_fixed_relaxation_get_residual_L2_Norm_2fx_pair(mui_algorithm_fixed_relaxation_2fx *fr, float t, float it);
+double mui_fixed_relaxation_get_residual_L2_Norm_2d_pair(mui_algorithm_fixed_relaxation_2d *fr, double t, double it);
+double mui_fixed_relaxation_get_residual_L2_Norm_2dx_pair(mui_algorithm_fixed_relaxation_2dx *fr, double t, double it);
+double mui_fixed_relaxation_get_residual_L2_Norm_2t_pair(mui_algorithm_fixed_relaxation_2t *fr, double t, double it);
+
 // Aitken's algorithms functions for get info
 float mui_aitken_get_under_relaxation_factor_2f(mui_algorithm_aitken_2f *aitken, float t);
 float mui_aitken_get_under_relaxation_factor_2fx(mui_algorithm_aitken_2fx *aitken, float t);

--- a/wrappers/C/mui_c_wrapper_2d.h
+++ b/wrappers/C/mui_c_wrapper_2d.h
@@ -363,15 +363,15 @@ void mui_destroy_temporal_sampler_sum_2dx(mui_temporal_sampler_sum_2dx *sampler)
 void mui_destroy_temporal_sampler_sum_2t(mui_temporal_sampler_sum_2t *sampler);
 
 // MUI algorithms creation
-mui_algorithm_fixed_relaxation_2f* mui_create_algorithm_fixed_relaxation_2f(float under_relaxation_factor, mui_point_2f *points,
+mui_algorithm_fixed_relaxation_2f* mui_create_algorithm_fixed_relaxation_2f(float under_relaxation_factor, MPI_Comm communicator, mui_point_2f *points,
 		float *value_init, int pair_count);
-mui_algorithm_fixed_relaxation_2fx* mui_create_algorithm_fixed_relaxation_2fx(float under_relaxation_factor, mui_point_2fx *points,
+mui_algorithm_fixed_relaxation_2fx* mui_create_algorithm_fixed_relaxation_2fx(float under_relaxation_factor, MPI_Comm communicator, mui_point_2fx *points,
 		float *value_init, int pair_count);
-mui_algorithm_fixed_relaxation_2d* mui_create_algorithm_fixed_relaxation_2d(double under_relaxation_factor, mui_point_2d *points,
+mui_algorithm_fixed_relaxation_2d* mui_create_algorithm_fixed_relaxation_2d(double under_relaxation_factor, MPI_Comm communicator, mui_point_2d *points,
 		double *value_init, int pair_count);
-mui_algorithm_fixed_relaxation_2dx* mui_create_algorithm_fixed_relaxation_2dx(double under_relaxation_factor, mui_point_2dx *points,
+mui_algorithm_fixed_relaxation_2dx* mui_create_algorithm_fixed_relaxation_2dx(double under_relaxation_factor, MPI_Comm communicator, mui_point_2dx *points,
 		double *value_init, int pair_count);
-mui_algorithm_fixed_relaxation_2t* mui_create_algorithm_fixed_relaxation_2t(double under_relaxation_factor, mui_point_2t *points,
+mui_algorithm_fixed_relaxation_2t* mui_create_algorithm_fixed_relaxation_2t(double under_relaxation_factor, MPI_Comm communicator, mui_point_2t *points,
 		double *value_init, int pair_count);
 mui_algorithm_aitken_2f* mui_create_algorithm_aitken_2f(float under_relaxation_factor, float under_relaxation_factor_max,
 		MPI_Comm communicator, mui_point_2f *points, float *value_init, int pair_count, float res_l2_norm_nm1);

--- a/wrappers/C/mui_c_wrapper_3d.cpp
+++ b/wrappers/C/mui_c_wrapper_3d.cpp
@@ -1261,8 +1261,92 @@ mui_algorithm_aitken_3t* mui_create_algorithm_aitken_3t(double under_relaxation_
 }
 
 /*******************************************
- * Aitken's functions for get info         *
+ * Algorithms functions for get info         *
  *******************************************/
+
+// Fixed relaxation get under relaxation factor functions
+float mui_fixed_relaxation_get_under_relaxation_factor_3f(mui_algorithm_fixed_relaxation_3f *fr, float t) {
+	return fr->get_under_relaxation_factor(t);
+}
+
+float mui_fixed_relaxation_get_under_relaxation_factor_3fx(mui_algorithm_fixed_relaxation_3fx *fr, float t) {
+	return fr->get_under_relaxation_factor(t);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_3d(mui_algorithm_fixed_relaxation_3d *fr, double t) {
+	return fr->get_under_relaxation_factor(t);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_3dx(mui_algorithm_fixed_relaxation_3dx *fr, double t) {
+	return fr->get_under_relaxation_factor(t);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_3t(mui_algorithm_fixed_relaxation_3t *fr, double t) {
+	return fr->get_under_relaxation_factor(static_cast<mui::mui_c_wrapper_3D::time_type>(t));
+}
+
+float mui_fixed_relaxation_get_under_relaxation_factor_3f_pair(mui_algorithm_fixed_relaxation_3f *fr, float t, float it) {
+	return fr->get_under_relaxation_factor(t, it);
+}
+
+float mui_fixed_relaxation_get_under_relaxation_factor_3fx_pair(mui_algorithm_fixed_relaxation_3fx *fr, float t, float it) {
+	return fr->get_under_relaxation_factor(t, it);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_3d_pair(mui_algorithm_fixed_relaxation_3d *fr, double t, double it) {
+	return fr->get_under_relaxation_factor(t, it);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_3dx_pair(mui_algorithm_fixed_relaxation_3dx *fr, double t, double it) {
+	return fr->get_under_relaxation_factor(t, it);
+}
+
+double mui_fixed_relaxation_get_under_relaxation_factor_3t_pair(mui_algorithm_fixed_relaxation_3t *fr, double t, double it) {
+	return fr->get_under_relaxation_factor(static_cast<mui::mui_c_wrapper_3D::time_type>(t),
+			static_cast<mui::mui_c_wrapper_3D::iterator_type>(it));
+}
+
+// Fixed relaxation get under relaxation factor functions
+float mui_fixed_relaxation_get_residual_L2_Norm_3f(mui_algorithm_fixed_relaxation_3f *fr, float t) {
+	return fr->get_residual_L2_Norm(t);
+}
+
+float mui_fixed_relaxation_get_residual_L2_Norm_3fx(mui_algorithm_fixed_relaxation_3fx *fr, float t) {
+	return fr->get_residual_L2_Norm(t);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_3d(mui_algorithm_fixed_relaxation_3d *fr, double t) {
+	return fr->get_residual_L2_Norm(t);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_3dx(mui_algorithm_fixed_relaxation_3dx *fr, double t) {
+	return fr->get_residual_L2_Norm(t);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_3t(mui_algorithm_fixed_relaxation_3t *fr, double t) {
+	return fr->get_residual_L2_Norm(static_cast<mui::mui_c_wrapper_3D::time_type>(t));
+}
+
+float mui_fixed_relaxation_get_residual_L2_Norm_3f_pair(mui_algorithm_fixed_relaxation_3f *fr, float t, float it) {
+	return fr->get_residual_L2_Norm(t, it);
+}
+
+float mui_fixed_relaxation_get_residual_L2_Norm_3fx_pair(mui_algorithm_fixed_relaxation_3fx *fr, float t, float it) {
+	return fr->get_residual_L2_Norm(t, it);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_3d_pair(mui_algorithm_fixed_relaxation_3d *fr, double t, double it) {
+	return fr->get_residual_L2_Norm(t, it);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_3dx_pair(mui_algorithm_fixed_relaxation_3dx *fr, double t, double it) {
+	return fr->get_residual_L2_Norm(t, it);
+}
+
+double mui_fixed_relaxation_get_residual_L2_Norm_3t_pair(mui_algorithm_fixed_relaxation_3t *fr, double t, double it) {
+	return fr->get_residual_L2_Norm(static_cast<mui::mui_c_wrapper_3D::time_type>(t),
+			static_cast<mui::mui_c_wrapper_3D::iterator_type>(it));
+}
 
 // Aitken's get under relaxation factor functions
 float mui_aitken_get_under_relaxation_factor_3f(mui_algorithm_aitken_3f *aitken, float t) {

--- a/wrappers/C/mui_c_wrapper_3d.cpp
+++ b/wrappers/C/mui_c_wrapper_3d.cpp
@@ -1059,7 +1059,7 @@ void mui_destroy_temporal_sampler_sum_3t(mui_temporal_sampler_sum_3t *sampler) {
  *******************************************/
 
 // Fixed relaxation algorithm
-mui_algorithm_fixed_relaxation_3f* mui_create_algorithm_fixed_relaxation_3f(float under_relaxation_factor = 1.0, mui_point_3f *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_3f* mui_create_algorithm_fixed_relaxation_3f(float under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_3f *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::point3f, float>> pts_value_init;
 
@@ -1076,10 +1076,10 @@ mui_algorithm_fixed_relaxation_3f* mui_create_algorithm_fixed_relaxation_3f(floa
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_3f(under_relaxation_factor, pts_value_init);
+	return new mui_algorithm_fixed_relaxation_3f(under_relaxation_factor, communicator, pts_value_init);
 }
 
-mui_algorithm_fixed_relaxation_3fx* mui_create_algorithm_fixed_relaxation_3fx(float under_relaxation_factor = 1.0, mui_point_3fx *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_3fx* mui_create_algorithm_fixed_relaxation_3fx(float under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_3fx *points = nullptr, float *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::point3fx, float>> pts_value_init;
 
@@ -1096,10 +1096,10 @@ mui_algorithm_fixed_relaxation_3fx* mui_create_algorithm_fixed_relaxation_3fx(fl
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_3fx(under_relaxation_factor, pts_value_init);
+	return new mui_algorithm_fixed_relaxation_3fx(under_relaxation_factor, communicator, pts_value_init);
 }
 
-mui_algorithm_fixed_relaxation_3d* mui_create_algorithm_fixed_relaxation_3d(double under_relaxation_factor = 1.0, mui_point_3d *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_3d* mui_create_algorithm_fixed_relaxation_3d(double under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_3d *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::point3d, double>> pts_value_init;
 
@@ -1116,10 +1116,10 @@ mui_algorithm_fixed_relaxation_3d* mui_create_algorithm_fixed_relaxation_3d(doub
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_3d(under_relaxation_factor, pts_value_init);
+	return new mui_algorithm_fixed_relaxation_3d(under_relaxation_factor, communicator, pts_value_init);
 }
 
-mui_algorithm_fixed_relaxation_3dx* mui_create_algorithm_fixed_relaxation_3dx(double under_relaxation_factor = 1.0, mui_point_3dx *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_3dx* mui_create_algorithm_fixed_relaxation_3dx(double under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_3dx *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::point3dx, double>> pts_value_init;
 
@@ -1136,10 +1136,10 @@ mui_algorithm_fixed_relaxation_3dx* mui_create_algorithm_fixed_relaxation_3dx(do
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_3dx(under_relaxation_factor, pts_value_init);
+	return new mui_algorithm_fixed_relaxation_3dx(under_relaxation_factor, communicator, pts_value_init);
 }
 
-mui_algorithm_fixed_relaxation_3t* mui_create_algorithm_fixed_relaxation_3t(double under_relaxation_factor = 1.0, mui_point_3t *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
+mui_algorithm_fixed_relaxation_3t* mui_create_algorithm_fixed_relaxation_3t(double under_relaxation_factor = 1.0, MPI_Comm communicator = MPI_COMM_NULL, mui_point_3t *points = nullptr, double *value_init = nullptr, int pair_count = 0) {
 
 	std::vector<std::pair<mui::mui_c_wrapper_3D::point_type, mui::mui_c_wrapper_3D::REAL>> pts_value_init;
 
@@ -1156,7 +1156,7 @@ mui_algorithm_fixed_relaxation_3t* mui_create_algorithm_fixed_relaxation_3t(doub
 		}
 	}
 
-	return new mui_algorithm_fixed_relaxation_3t(static_cast<mui::mui_c_wrapper_3D::REAL>(under_relaxation_factor), pts_value_init);
+	return new mui_algorithm_fixed_relaxation_3t(static_cast<mui::mui_c_wrapper_3D::REAL>(under_relaxation_factor), communicator, pts_value_init);
 }
 
 // Aitken's algorithm

--- a/wrappers/C/mui_c_wrapper_3d.h
+++ b/wrappers/C/mui_c_wrapper_3d.h
@@ -389,6 +389,28 @@ mui_algorithm_aitken_3dx* mui_create_algorithm_aitken_3dx(double under_relaxatio
 mui_algorithm_aitken_3t* mui_create_algorithm_aitken_3t(double under_relaxation_factor, double under_relaxation_factor_max,
 		MPI_Comm communicator, mui_point_3t *points, double *value_init, int pair_count, double res_l2_norm_nm1);
 
+// Fixed relaxation algorithms functions for get info
+float mui_fixed_relaxation_get_under_relaxation_factor_3f(mui_algorithm_fixed_relaxation_3f *fr, float t);
+float mui_fixed_relaxation_get_under_relaxation_factor_3fx(mui_algorithm_fixed_relaxation_3fx *fr, float t);
+double mui_fixed_relaxation_get_under_relaxation_factor_3d(mui_algorithm_fixed_relaxation_3d *fr, double t);
+double mui_fixed_relaxation_get_under_relaxation_factor_3dx(mui_algorithm_fixed_relaxation_3dx *fr, double t);
+double mui_fixed_relaxation_get_under_relaxation_factor_3t(mui_algorithm_fixed_relaxation_3t *fr, double t);
+float mui_fixed_relaxation_get_under_relaxation_factor_3f_pair(mui_algorithm_fixed_relaxation_3f *fr, float t, float it);
+float mui_fixed_relaxation_get_under_relaxation_factor_3fx_pair(mui_algorithm_fixed_relaxation_3fx *fr, float t, float it);
+double mui_fixed_relaxation_get_under_relaxation_factor_3d_pair(mui_algorithm_fixed_relaxation_3d *fr, double t, double it);
+double mui_fixed_relaxation_get_under_relaxation_factor_3dx_pair(mui_algorithm_fixed_relaxation_3dx *fr, double t, double it);
+double mui_fixed_relaxation_get_under_relaxation_factor_3t_pair(mui_algorithm_fixed_relaxation_3t *fr, double t, double it);
+float mui_fixed_relaxation_get_residual_L2_Norm_3f(mui_algorithm_fixed_relaxation_3f *fr, float t);
+float mui_fixed_relaxation_get_residual_L2_Norm_3fx(mui_algorithm_fixed_relaxation_3fx *fr, float t);
+double mui_fixed_relaxation_get_residual_L2_Norm_3d(mui_algorithm_fixed_relaxation_3d *fr, double t);
+double mui_fixed_relaxation_get_residual_L2_Norm_3dx(mui_algorithm_fixed_relaxation_3dx *fr, double t);
+double mui_fixed_relaxation_get_residual_L2_Norm_3t(mui_algorithm_fixed_relaxation_3t *fr, double t);
+float mui_fixed_relaxation_get_residual_L2_Norm_3f_pair(mui_algorithm_fixed_relaxation_3f *fr, float t, float it);
+float mui_fixed_relaxation_get_residual_L2_Norm_3fx_pair(mui_algorithm_fixed_relaxation_3fx *fr, float t, float it);
+double mui_fixed_relaxation_get_residual_L2_Norm_3d_pair(mui_algorithm_fixed_relaxation_3d *fr, double t, double it);
+double mui_fixed_relaxation_get_residual_L2_Norm_3dx_pair(mui_algorithm_fixed_relaxation_3dx *fr, double t, double it);
+double mui_fixed_relaxation_get_residual_L2_Norm_3t_pair(mui_algorithm_fixed_relaxation_3t *fr, double t, double it);
+
 // Aitken's algorithms functions for get info
 float mui_aitken_get_under_relaxation_factor_3f(mui_algorithm_aitken_3f *aitken, float t);
 float mui_aitken_get_under_relaxation_factor_3fx(mui_algorithm_aitken_3fx *aitken, float t);

--- a/wrappers/C/mui_c_wrapper_3d.h
+++ b/wrappers/C/mui_c_wrapper_3d.h
@@ -368,15 +368,15 @@ void mui_destroy_temporal_sampler_sum_3dx(mui_temporal_sampler_sum_3dx *sampler)
 void mui_destroy_temporal_sampler_sum_3t(mui_temporal_sampler_sum_3t *sampler);
 
 // MUI algorithms creation
-mui_algorithm_fixed_relaxation_3f* mui_create_algorithm_fixed_relaxation_3f(float under_relaxation_factor, mui_point_3f *points,
+mui_algorithm_fixed_relaxation_3f* mui_create_algorithm_fixed_relaxation_3f(float under_relaxation_factor, MPI_Comm communicator, mui_point_3f *points,
 		float *value_init, int pair_count);
-mui_algorithm_fixed_relaxation_3fx* mui_create_algorithm_fixed_relaxation_3fx(float under_relaxation_factor, mui_point_3fx *points,
+mui_algorithm_fixed_relaxation_3fx* mui_create_algorithm_fixed_relaxation_3fx(float under_relaxation_factor, MPI_Comm communicator, mui_point_3fx *points,
 		float *value_init, int pair_count);
-mui_algorithm_fixed_relaxation_3d* mui_create_algorithm_fixed_relaxation_3d(double under_relaxation_factor, mui_point_3d *points,
+mui_algorithm_fixed_relaxation_3d* mui_create_algorithm_fixed_relaxation_3d(double under_relaxation_factor, MPI_Comm communicator, mui_point_3d *points,
 		double *value_init, int pair_count);
-mui_algorithm_fixed_relaxation_3dx* mui_create_algorithm_fixed_relaxation_3dx(double under_relaxation_factor, mui_point_3dx *points,
+mui_algorithm_fixed_relaxation_3dx* mui_create_algorithm_fixed_relaxation_3dx(double under_relaxation_factor, MPI_Comm communicator, mui_point_3dx *points,
 		double *value_init, int pair_count);
-mui_algorithm_fixed_relaxation_3t* mui_create_algorithm_fixed_relaxation_3t(double under_relaxation_factor, mui_point_3t *points,
+mui_algorithm_fixed_relaxation_3t* mui_create_algorithm_fixed_relaxation_3t(double under_relaxation_factor, MPI_Comm communicator, mui_point_3t *points,
 		double *value_init, int pair_count);
 mui_algorithm_aitken_3f* mui_create_algorithm_aitken_3f(float under_relaxation_factor, float under_relaxation_factor_max,
 		MPI_Comm communicator, mui_point_3f *points, float *value_init, int pair_count, float res_l2_norm_nm1);

--- a/wrappers/Fortran/mui_f_wrapper_1d.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_1d.cpp
@@ -1345,8 +1345,93 @@ void mui_create_algorithm_aitken_1t_f(mui_algorithm_aitken_1t** ret, double* und
 }
 
 /*******************************************
- * Aitken's functions for get info         *
+ * Algorithms functions for get info         *
  *******************************************/
+
+// Fixed relaxation get under relaxation factor functions
+void mui_fixed_relaxation_get_under_relaxation_factor_1f_f(mui_algorithm_fixed_relaxation_1f *fr, float* t, float *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t);
+}
+
+
+void mui_fixed_relaxation_get_under_relaxation_factor_1fx_f(mui_algorithm_fixed_relaxation_1fx *fr, float* t, float *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_1d_f(mui_algorithm_fixed_relaxation_1d *fr, double* t, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_1dx_f(mui_algorithm_fixed_relaxation_1dx *fr, double* t, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_1t_f(mui_algorithm_fixed_relaxation_1t *fr, double* t, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(static_cast<mui::mui_f_wrapper_1D::time_type>(*t));
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_1f_pair_f(mui_algorithm_fixed_relaxation_1f *fr, float* t, float* it, float *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_1fx_pair_f(mui_algorithm_fixed_relaxation_1fx *fr, float* t, float* it, float *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_1d_pair_f(mui_algorithm_fixed_relaxation_1d *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_1dx_pair_f(mui_algorithm_fixed_relaxation_1dx *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_1t_pair_f(mui_algorithm_fixed_relaxation_1t *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(static_cast<mui::mui_f_wrapper_1D::time_type>(*t),
+			static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it));
+}
+
+// Fixed relaxation get residual L2 Norm functions
+void mui_fixed_relaxation_get_residual_1f_f(mui_algorithm_fixed_relaxation_1f *fr, float* t, float *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t);
+}
+
+void mui_fixed_relaxation_get_residual_1fx_f(mui_algorithm_fixed_relaxation_1fx *fr, float* t, float *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t);
+}
+
+void mui_fixed_relaxation_get_residual_1d_f(mui_algorithm_fixed_relaxation_1d *fr, double* t, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t);
+}
+
+void mui_fixed_relaxation_get_residual_1dx_f(mui_algorithm_fixed_relaxation_1dx *fr, double* t, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t);
+}
+
+void mui_fixed_relaxation_get_residual_1t_f(mui_algorithm_fixed_relaxation_1t *fr, double* t, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(static_cast<mui::mui_f_wrapper_1D::time_type>(*t));
+}
+
+void mui_fixed_relaxation_get_residual_1f_pair_f(mui_algorithm_fixed_relaxation_1f *fr, float* t, float* it, float *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_fixed_relaxation_get_residual_1fx_pair_f(mui_algorithm_fixed_relaxation_1fx *fr, float* t, float* it, float *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_fixed_relaxation_get_residual_1d_pair_f(mui_algorithm_fixed_relaxation_1d *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_fixed_relaxation_get_residual_1dx_pair_f(mui_algorithm_fixed_relaxation_1dx *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_fixed_relaxation_get_residual_1t_pair_f(mui_algorithm_fixed_relaxation_1t *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(static_cast<mui::mui_f_wrapper_1D::time_type>(*t),
+			static_cast<mui::mui_f_wrapper_1D::iterator_type>(*it));
+}
 
 // Aitken's get under relaxation factor functions
 void mui_aitken_get_under_relaxation_factor_1f_f(mui_algorithm_aitken_1f *aitken, float* t, float *return_value) {

--- a/wrappers/Fortran/mui_f_wrapper_1d.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_1d.cpp
@@ -1163,7 +1163,7 @@ void mui_destroy_temporal_sampler_sum_1t_f(mui_temporal_sampler_sum_1t* sampler)
  *******************************************/
 
 // Fixed relaxation algorithm
-void mui_create_algorithm_fixed_relaxation_1f_f(mui_algorithm_fixed_relaxation_1f **ret, float* under_relaxation_factor, float* points_1, float* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_1f_f(mui_algorithm_fixed_relaxation_1f **ret, float* under_relaxation_factor, MPI_Comm* communicator, float* points_1, float* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point1f, float>> pts_value_init;
 
@@ -1178,10 +1178,10 @@ void mui_create_algorithm_fixed_relaxation_1f_f(mui_algorithm_fixed_relaxation_1
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_1f(*under_relaxation_factor, pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_1f(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_1fx_f(mui_algorithm_fixed_relaxation_1fx **ret, float* under_relaxation_factor, float* points_1, float* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_1fx_f(mui_algorithm_fixed_relaxation_1fx **ret, float* under_relaxation_factor, MPI_Comm* communicator, float* points_1, float* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point1fx, float>> pts_value_init;
 
@@ -1196,10 +1196,10 @@ void mui_create_algorithm_fixed_relaxation_1fx_f(mui_algorithm_fixed_relaxation_
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_1fx(*under_relaxation_factor, pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_1fx(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_1d_f(mui_algorithm_fixed_relaxation_1d **ret, double* under_relaxation_factor, double* points_1, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_1d_f(mui_algorithm_fixed_relaxation_1d **ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point1d, double>> pts_value_init;
 
@@ -1214,10 +1214,10 @@ void mui_create_algorithm_fixed_relaxation_1d_f(mui_algorithm_fixed_relaxation_1
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_1d(*under_relaxation_factor, pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_1d(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_1dx_f(mui_algorithm_fixed_relaxation_1dx** ret, double* under_relaxation_factor, double* points_1, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_1dx_f(mui_algorithm_fixed_relaxation_1dx** ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point1dx, double>> pts_value_init;
 
@@ -1232,10 +1232,10 @@ void mui_create_algorithm_fixed_relaxation_1dx_f(mui_algorithm_fixed_relaxation_
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_1dx(*under_relaxation_factor, pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_1dx(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_1t_f(mui_algorithm_fixed_relaxation_1t** ret, double* under_relaxation_factor, double* points_1, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_1t_f(mui_algorithm_fixed_relaxation_1t** ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::mui_f_wrapper_1D::point_type, mui::mui_f_wrapper_1D::REAL>> pts_value_init;
 
@@ -1250,7 +1250,7 @@ void mui_create_algorithm_fixed_relaxation_1t_f(mui_algorithm_fixed_relaxation_1
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_1t(static_cast<mui::mui_f_wrapper_1D::REAL>(*under_relaxation_factor), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_1t(static_cast<mui::mui_f_wrapper_1D::REAL>(*under_relaxation_factor), reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
 // Aitken's algorithm

--- a/wrappers/Fortran/mui_f_wrapper_1d.f90
+++ b/wrappers/Fortran/mui_f_wrapper_1d.f90
@@ -1208,8 +1208,170 @@ module mui_1d_f
     end subroutine mui_create_algorithm_aitken_1t_f
 
     !******************************************
-    !* Aitken's functions for get info        *
+    !* Algorithms functions for get info        *
     !******************************************
+
+    !Fixed relaxation get under relaxation factor functions
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_1f_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_1f_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_1fx_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_1fx_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_1d_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_1d_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_1dx_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_1dx_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_1t_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_1t_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_1f_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_1f_pair_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_1fx_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_1fx_pair_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_1d_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_1d_pair_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_1dx_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_1dx_pair_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_1t_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_1t_pair_f
+
+    !Fixed relaxation get residual L2 Norm functions
+    subroutine mui_fixed_relaxation_get_residual_1f_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_1f_f
+
+    subroutine mui_fixed_relaxation_get_residual_1fx_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_1fx_f
+
+    subroutine mui_fixed_relaxation_get_residual_1d_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_1d_f
+
+    subroutine mui_fixed_relaxation_get_residual_1dx_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_1dx_f
+
+    subroutine mui_fixed_relaxation_get_residual_1t_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_1t_f
+
+    subroutine mui_fixed_relaxation_get_residual_1f_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_1f_pair_f
+
+    subroutine mui_fixed_relaxation_get_residual_1fx_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_1fx_pair_f
+
+    subroutine mui_fixed_relaxation_get_residual_1d_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_1d_pair_f
+
+    subroutine mui_fixed_relaxation_get_residual_1dx_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_1dx_pair_f
+
+    subroutine mui_fixed_relaxation_get_residual_1t_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_1t_pair_f
 
     !Aitken's get under relaxation factor functions
     subroutine mui_aitken_get_under_relaxation_factor_1f_f(algorithm,t, &

--- a/wrappers/Fortran/mui_f_wrapper_1d.f90
+++ b/wrappers/Fortran/mui_f_wrapper_1d.f90
@@ -1087,9 +1087,10 @@ module mui_1d_f
 
     !Fixed relaxation algorithm
     subroutine mui_create_algorithm_fixed_relaxation_1f_f(algorithm, &
-        under_relaxation_factor,points_1,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,value_init,pair_count) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_float),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_float), intent(in), dimension(pair_count), target :: points_1
@@ -1097,9 +1098,10 @@ module mui_1d_f
     end subroutine mui_create_algorithm_fixed_relaxation_1f_f
 
     subroutine mui_create_algorithm_fixed_relaxation_1fx_f(algorithm, &
-        under_relaxation_factor,points_1,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,value_init,pair_count) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_float),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_float), intent(in), dimension(pair_count), target :: points_1
@@ -1107,9 +1109,10 @@ module mui_1d_f
     end subroutine mui_create_algorithm_fixed_relaxation_1fx_f
 
     subroutine mui_create_algorithm_fixed_relaxation_1d_f(algorithm, &
-        under_relaxation_factor,points_1,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1
@@ -1117,9 +1120,10 @@ module mui_1d_f
     end subroutine mui_create_algorithm_fixed_relaxation_1d_f
 
     subroutine mui_create_algorithm_fixed_relaxation_1dx_f(algorithm, &
-        under_relaxation_factor,points_1,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1
@@ -1127,9 +1131,10 @@ module mui_1d_f
     end subroutine mui_create_algorithm_fixed_relaxation_1dx_f
 
     subroutine mui_create_algorithm_fixed_relaxation_1t_f(algorithm, &
-        under_relaxation_factor,points_1,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1

--- a/wrappers/Fortran/mui_f_wrapper_2d.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_2d.cpp
@@ -1360,8 +1360,93 @@ void mui_create_algorithm_aitken_2t_f(mui_algorithm_aitken_2t** ret, double* und
 }
 
 /*******************************************
- * Aitken's functions for get info         *
+ * Algorithms functions for get info         *
  *******************************************/
+
+// Fixed relaxation get under relaxation factor functions
+void mui_fixed_relaxation_get_under_relaxation_factor_2f_f(mui_algorithm_fixed_relaxation_2f *fr, float* t, float *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t);
+}
+
+
+void mui_fixed_relaxation_get_under_relaxation_factor_2fx_f(mui_algorithm_fixed_relaxation_2fx *fr, float* t, float *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_2d_f(mui_algorithm_fixed_relaxation_2d *fr, double* t, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_2dx_f(mui_algorithm_fixed_relaxation_2dx *fr, double* t, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_2t_f(mui_algorithm_fixed_relaxation_2t *fr, double* t, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(static_cast<mui::mui_f_wrapper_2D::time_type>(*t));
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_2f_pair_f(mui_algorithm_fixed_relaxation_2f *fr, float* t, float* it, float *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_2fx_pair_f(mui_algorithm_fixed_relaxation_2fx *fr, float* t, float* it, float *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_2d_pair_f(mui_algorithm_fixed_relaxation_2d *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_2dx_pair_f(mui_algorithm_fixed_relaxation_2dx *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_2t_pair_f(mui_algorithm_fixed_relaxation_2t *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(static_cast<mui::mui_f_wrapper_2D::time_type>(*t),
+			static_cast<mui::mui_f_wrapper_2D::iterator_type>(*it));
+}
+
+// Fixed relaxation get residual L2 Norm functions
+void mui_fixed_relaxation_get_residual_2f_f(mui_algorithm_fixed_relaxation_2f *fr, float* t, float *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t);
+}
+
+void mui_fixed_relaxation_get_residual_2fx_f(mui_algorithm_fixed_relaxation_2fx *fr, float* t, float *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t);
+}
+
+void mui_fixed_relaxation_get_residual_2d_f(mui_algorithm_fixed_relaxation_2d *fr, double* t, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t);
+}
+
+void mui_fixed_relaxation_get_residual_2dx_f(mui_algorithm_fixed_relaxation_2dx *fr, double* t, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t);
+}
+
+void mui_fixed_relaxation_get_residual_2t_f(mui_algorithm_fixed_relaxation_2t *fr, double* t, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(static_cast<mui::mui_f_wrapper_2D::time_type>(*t));
+}
+
+void mui_fixed_relaxation_get_residual_2f_pair_f(mui_algorithm_fixed_relaxation_2f *fr, float* t, float* it, float *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_fixed_relaxation_get_residual_2fx_pair_f(mui_algorithm_fixed_relaxation_2fx *fr, float* t, float* it, float *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_fixed_relaxation_get_residual_2d_pair_f(mui_algorithm_fixed_relaxation_2d *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_fixed_relaxation_get_residual_2dx_pair_f(mui_algorithm_fixed_relaxation_2dx *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_fixed_relaxation_get_residual_2t_pair_f(mui_algorithm_fixed_relaxation_2t *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(static_cast<mui::mui_f_wrapper_2D::time_type>(*t),
+			static_cast<mui::mui_f_wrapper_2D::iterator_type>(*it));
+}
 
 // Aitken's get under relaxation factor functions
 void mui_aitken_get_under_relaxation_factor_2f_f(mui_algorithm_aitken_2f *aitken, float* t, float *return_value) {

--- a/wrappers/Fortran/mui_f_wrapper_2d.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_2d.cpp
@@ -1168,7 +1168,7 @@ void mui_destroy_temporal_sampler_sum_2t_f(mui_temporal_sampler_sum_2t* sampler)
  *******************************************/
 
 // Fixed relaxation algorithm
-void mui_create_algorithm_fixed_relaxation_2f_f(mui_algorithm_fixed_relaxation_2f **ret, float* under_relaxation_factor, float* points_1, float* points_2, float* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_2f_f(mui_algorithm_fixed_relaxation_2f **ret, float* under_relaxation_factor, MPI_Comm* communicator, float* points_1, float* points_2, float* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point2f, float>> pts_value_init;
 
@@ -1184,10 +1184,10 @@ void mui_create_algorithm_fixed_relaxation_2f_f(mui_algorithm_fixed_relaxation_2
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_2f(*under_relaxation_factor, pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_2f(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_2fx_f(mui_algorithm_fixed_relaxation_2fx **ret, float* under_relaxation_factor, float* points_1, float* points_2, float* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_2fx_f(mui_algorithm_fixed_relaxation_2fx **ret, float* under_relaxation_factor, MPI_Comm* communicator, float* points_1, float* points_2, float* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point2fx, float>> pts_value_init;
 
@@ -1203,10 +1203,10 @@ void mui_create_algorithm_fixed_relaxation_2fx_f(mui_algorithm_fixed_relaxation_
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_2fx(*under_relaxation_factor, pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_2fx(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_2d_f(mui_algorithm_fixed_relaxation_2d **ret, double* under_relaxation_factor, double* points_1, double* points_2, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_2d_f(mui_algorithm_fixed_relaxation_2d **ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* points_2, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point2d, double>> pts_value_init;
 
@@ -1222,10 +1222,10 @@ void mui_create_algorithm_fixed_relaxation_2d_f(mui_algorithm_fixed_relaxation_2
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_2d(*under_relaxation_factor, pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_2d(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_2dx_f(mui_algorithm_fixed_relaxation_2dx** ret, double* under_relaxation_factor, double* points_1, double* points_2, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_2dx_f(mui_algorithm_fixed_relaxation_2dx** ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* points_2, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point2dx, double>> pts_value_init;
 
@@ -1241,10 +1241,10 @@ void mui_create_algorithm_fixed_relaxation_2dx_f(mui_algorithm_fixed_relaxation_
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_2dx(*under_relaxation_factor, pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_2dx(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_2t_f(mui_algorithm_fixed_relaxation_2t** ret, double* under_relaxation_factor, double* points_1, double* points_2, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_2t_f(mui_algorithm_fixed_relaxation_2t** ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* points_2, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::mui_f_wrapper_2D::point_type, mui::mui_f_wrapper_2D::REAL>> pts_value_init;
 
@@ -1260,7 +1260,7 @@ void mui_create_algorithm_fixed_relaxation_2t_f(mui_algorithm_fixed_relaxation_2
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_2t(static_cast<mui::mui_f_wrapper_2D::REAL>(*under_relaxation_factor), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_2t(static_cast<mui::mui_f_wrapper_2D::REAL>(*under_relaxation_factor), reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
 // Aitken's algorithm

--- a/wrappers/Fortran/mui_f_wrapper_2d.f90
+++ b/wrappers/Fortran/mui_f_wrapper_2d.f90
@@ -1188,8 +1188,170 @@ module mui_2d_f
     end subroutine mui_create_algorithm_aitken_2t_f
 
     !******************************************
-    !* Aitken's functions for get info        *
+    !* Algorithms functions for get info        *
     !******************************************
+
+    !Fixed relaxation get under relaxation factor functions
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_2f_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_2f_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_2fx_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_2fx_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_2d_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_2d_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_2dx_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_2dx_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_2t_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_2t_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_2f_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_2f_pair_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_2fx_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_2fx_pair_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_2d_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_2d_pair_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_2dx_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_2dx_pair_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_2t_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_2t_pair_f
+
+    !Fixed relaxation get residual L2 Norm functions
+    subroutine mui_fixed_relaxation_get_residual_2f_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_2f_f
+
+    subroutine mui_fixed_relaxation_get_residual_2fx_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_2fx_f
+
+    subroutine mui_fixed_relaxation_get_residual_2d_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_2d_f
+
+    subroutine mui_fixed_relaxation_get_residual_2dx_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_2dx_f
+
+    subroutine mui_fixed_relaxation_get_residual_2t_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_2t_f
+
+    subroutine mui_fixed_relaxation_get_residual_2f_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_2f_pair_f
+
+    subroutine mui_fixed_relaxation_get_residual_2fx_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_2fx_pair_f
+
+    subroutine mui_fixed_relaxation_get_residual_2d_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_2d_pair_f
+
+    subroutine mui_fixed_relaxation_get_residual_2dx_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_2dx_pair_f
+
+    subroutine mui_fixed_relaxation_get_residual_2t_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_2t_pair_f
 
     !Aitken's get under relaxation factor functions
     subroutine mui_aitken_get_under_relaxation_factor_2f_f(algorithm,t, &

--- a/wrappers/Fortran/mui_f_wrapper_2d.f90
+++ b/wrappers/Fortran/mui_f_wrapper_2d.f90
@@ -1067,9 +1067,10 @@ module mui_2d_f
 
     !Fixed relaxation algorithm
     subroutine mui_create_algorithm_fixed_relaxation_2f_f(algorithm, &
-        under_relaxation_factor,points_1,points_2,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,points_2,value_init,pair_count) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_float),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_float), intent(in), dimension(pair_count), target :: points_1,points_2
@@ -1077,9 +1078,10 @@ module mui_2d_f
     end subroutine mui_create_algorithm_fixed_relaxation_2f_f
 
     subroutine mui_create_algorithm_fixed_relaxation_2fx_f(algorithm, &
-        under_relaxation_factor,points_1,points_2,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,points_2,value_init,pair_count) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_float),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_float), intent(in), dimension(pair_count), target :: points_1,points_2
@@ -1087,9 +1089,10 @@ module mui_2d_f
     end subroutine mui_create_algorithm_fixed_relaxation_2fx_f
 
     subroutine mui_create_algorithm_fixed_relaxation_2d_f(algorithm, &
-        under_relaxation_factor,points_1,points_2,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,points_2,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1,points_2
@@ -1097,9 +1100,10 @@ module mui_2d_f
     end subroutine mui_create_algorithm_fixed_relaxation_2d_f
 
     subroutine mui_create_algorithm_fixed_relaxation_2dx_f(algorithm, &
-        under_relaxation_factor,points_1,points_2,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,points_2,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1,points_2
@@ -1107,9 +1111,10 @@ module mui_2d_f
     end subroutine mui_create_algorithm_fixed_relaxation_2dx_f
 
     subroutine mui_create_algorithm_fixed_relaxation_2t_f(algorithm, &
-        under_relaxation_factor,points_1,points_2,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,points_2,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1,points_2

--- a/wrappers/Fortran/mui_f_wrapper_3d.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_3d.cpp
@@ -1375,8 +1375,93 @@ void mui_create_algorithm_aitken_3t_f(mui_algorithm_aitken_3t** ret, double* und
 }
 
 /*******************************************
- * Aitken's functions for get info         *
+ * Algorithms functions for get info         *
  *******************************************/
+
+// Fixed relaxation get under relaxation factor functions
+void mui_fixed_relaxation_get_under_relaxation_factor_3f_f(mui_algorithm_fixed_relaxation_3f *fr, float* t, float *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t);
+}
+
+
+void mui_fixed_relaxation_get_under_relaxation_factor_3fx_f(mui_algorithm_fixed_relaxation_3fx *fr, float* t, float *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_3d_f(mui_algorithm_fixed_relaxation_3d *fr, double* t, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_3dx_f(mui_algorithm_fixed_relaxation_3dx *fr, double* t, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_3t_f(mui_algorithm_fixed_relaxation_3t *fr, double* t, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(static_cast<mui::mui_f_wrapper_3D::time_type>(*t));
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_3f_pair_f(mui_algorithm_fixed_relaxation_3f *fr, float* t, float* it, float *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_3fx_pair_f(mui_algorithm_fixed_relaxation_3fx *fr, float* t, float* it, float *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_3d_pair_f(mui_algorithm_fixed_relaxation_3d *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_3dx_pair_f(mui_algorithm_fixed_relaxation_3dx *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(*t, *it);
+}
+
+void mui_fixed_relaxation_get_under_relaxation_factor_3t_pair_f(mui_algorithm_fixed_relaxation_3t *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_under_relaxation_factor(static_cast<mui::mui_f_wrapper_3D::time_type>(*t),
+			static_cast<mui::mui_f_wrapper_3D::iterator_type>(*it));
+}
+
+// Fixed relaxation get residual L2 Norm functions
+void mui_fixed_relaxation_get_residual_3f_f(mui_algorithm_fixed_relaxation_3f *fr, float* t, float *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t);
+}
+
+void mui_fixed_relaxation_get_residual_3fx_f(mui_algorithm_fixed_relaxation_3fx *fr, float* t, float *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t);
+}
+
+void mui_fixed_relaxation_get_residual_3d_f(mui_algorithm_fixed_relaxation_3d *fr, double* t, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t);
+}
+
+void mui_fixed_relaxation_get_residual_3dx_f(mui_algorithm_fixed_relaxation_3dx *fr, double* t, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t);
+}
+
+void mui_fixed_relaxation_get_residual_3t_f(mui_algorithm_fixed_relaxation_3t *fr, double* t, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(static_cast<mui::mui_f_wrapper_3D::time_type>(*t));
+}
+
+void mui_fixed_relaxation_get_residual_3f_pair_f(mui_algorithm_fixed_relaxation_3f *fr, float* t, float* it, float *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_fixed_relaxation_get_residual_3fx_pair_f(mui_algorithm_fixed_relaxation_3fx *fr, float* t, float* it, float *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_fixed_relaxation_get_residual_3d_pair_f(mui_algorithm_fixed_relaxation_3d *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_fixed_relaxation_get_residual_3dx_pair_f(mui_algorithm_fixed_relaxation_3dx *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(*t, *it);
+}
+
+void mui_fixed_relaxation_get_residual_3t_pair_f(mui_algorithm_fixed_relaxation_3t *fr, double* t, double* it, double *return_value) {
+	*return_value = fr->get_residual_L2_Norm(static_cast<mui::mui_f_wrapper_3D::time_type>(*t),
+			static_cast<mui::mui_f_wrapper_3D::iterator_type>(*it));
+}
 
 // Aitken's get under relaxation factor functions
 void mui_aitken_get_under_relaxation_factor_3f_f(mui_algorithm_aitken_3f *aitken, float* t, float *return_value) {

--- a/wrappers/Fortran/mui_f_wrapper_3d.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_3d.cpp
@@ -1173,7 +1173,7 @@ void mui_destroy_temporal_sampler_sum_3t_f(mui_temporal_sampler_sum_3t* sampler)
  *******************************************/
 
 // Fixed relaxation algorithm
-void mui_create_algorithm_fixed_relaxation_3f_f(mui_algorithm_fixed_relaxation_3f **ret, float* under_relaxation_factor, float* points_1, float* points_2, float* points_3, float* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_3f_f(mui_algorithm_fixed_relaxation_3f **ret, float* under_relaxation_factor, MPI_Comm* communicator, float* points_1, float* points_2, float* points_3, float* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point3f, float>> pts_value_init;
 
@@ -1190,10 +1190,10 @@ void mui_create_algorithm_fixed_relaxation_3f_f(mui_algorithm_fixed_relaxation_3
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_3f(*under_relaxation_factor, pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_3f(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_3fx_f(mui_algorithm_fixed_relaxation_3fx **ret, float* under_relaxation_factor, float* points_1, float* points_2, float* points_3, float* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_3fx_f(mui_algorithm_fixed_relaxation_3fx **ret, float* under_relaxation_factor, MPI_Comm* communicator, float* points_1, float* points_2, float* points_3, float* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point3fx, float>> pts_value_init;
 
@@ -1210,10 +1210,10 @@ void mui_create_algorithm_fixed_relaxation_3fx_f(mui_algorithm_fixed_relaxation_
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_3fx(*under_relaxation_factor, pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_3fx(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_3d_f(mui_algorithm_fixed_relaxation_3d **ret, double* under_relaxation_factor, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_3d_f(mui_algorithm_fixed_relaxation_3d **ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point3d, double>> pts_value_init;
 
@@ -1230,10 +1230,10 @@ void mui_create_algorithm_fixed_relaxation_3d_f(mui_algorithm_fixed_relaxation_3
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_3d(*under_relaxation_factor, pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_3d(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_3dx_f(mui_algorithm_fixed_relaxation_3dx** ret, double* under_relaxation_factor, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_3dx_f(mui_algorithm_fixed_relaxation_3dx** ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point3dx, double>> pts_value_init;
 
@@ -1250,10 +1250,10 @@ void mui_create_algorithm_fixed_relaxation_3dx_f(mui_algorithm_fixed_relaxation_
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_3dx(*under_relaxation_factor, pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_3dx(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_3t_f(mui_algorithm_fixed_relaxation_3t** ret, double* under_relaxation_factor, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_3t_f(mui_algorithm_fixed_relaxation_3t** ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::mui_f_wrapper_3D::point_type, mui::mui_f_wrapper_3D::REAL>> pts_value_init;
 
@@ -1270,7 +1270,7 @@ void mui_create_algorithm_fixed_relaxation_3t_f(mui_algorithm_fixed_relaxation_3
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_3t(static_cast<mui::mui_f_wrapper_3D::REAL>(*under_relaxation_factor), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_3t(static_cast<mui::mui_f_wrapper_3D::REAL>(*under_relaxation_factor), reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
 }
 
 // Aitken's algorithm

--- a/wrappers/Fortran/mui_f_wrapper_3d.f90
+++ b/wrappers/Fortran/mui_f_wrapper_3d.f90
@@ -1188,8 +1188,170 @@ module mui_3d_f
     end subroutine mui_create_algorithm_aitken_3t_f
 
     !******************************************
-    !* Aitken's functions for get info        *
+    !* Algorithms functions for get info        *
     !******************************************
+
+    !Fixed relaxation get under relaxation factor functions
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_3f_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_3f_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_3fx_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_3fx_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_3d_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_3d_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_3dx_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_3dx_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_3t_f(algorithm,t, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_3t_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_3f_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_3f_pair_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_3fx_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_3fx_pair_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_3d_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_3d_pair_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_3dx_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_3dx_pair_f
+
+    subroutine mui_fixed_relaxation_get_under_relaxation_factor_3t_pair_f(algorithm,t, &
+        it,return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_under_relaxation_factor_3t_pair_f
+
+    !Fixed relaxation get residual L2 Norm functions
+    subroutine mui_fixed_relaxation_get_residual_3f_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_3f_f
+
+    subroutine mui_fixed_relaxation_get_residual_3fx_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_3fx_f
+
+    subroutine mui_fixed_relaxation_get_residual_3d_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_3d_f
+
+    subroutine mui_fixed_relaxation_get_residual_3dx_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_3dx_f
+
+    subroutine mui_fixed_relaxation_get_residual_3t_f(algorithm,t,return_value) &
+        bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_3t_f
+
+    subroutine mui_fixed_relaxation_get_residual_3f_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_3f_pair_f
+
+    subroutine mui_fixed_relaxation_get_residual_3fx_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_float
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_float), intent(in) :: t,it
+      real(kind=c_float), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_3fx_pair_f
+
+    subroutine mui_fixed_relaxation_get_residual_3d_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_3d_pair_f
+
+    subroutine mui_fixed_relaxation_get_residual_3dx_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_3dx_pair_f
+
+    subroutine mui_fixed_relaxation_get_residual_3t_pair_f(algorithm,t,it, &
+        return_value) bind(C)
+      import :: c_ptr,c_double
+      type(c_ptr), intent(in), value :: algorithm
+      real(kind=c_double), intent(in) :: t,it
+      real(kind=c_double), intent(out) :: return_value
+    end subroutine mui_fixed_relaxation_get_residual_3t_pair_f
 
     !Aitken's get under relaxation factor functions
     subroutine mui_aitken_get_under_relaxation_factor_3f_f(algorithm,t, &

--- a/wrappers/Fortran/mui_f_wrapper_3d.f90
+++ b/wrappers/Fortran/mui_f_wrapper_3d.f90
@@ -1067,9 +1067,10 @@ module mui_3d_f
 
     !Fixed relaxation algorithm
     subroutine mui_create_algorithm_fixed_relaxation_3f_f(algorithm, &
-        under_relaxation_factor,points_1,points_2,points_3,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,points_2,points_3,value_init,pair_count) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_float),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_float), intent(in), dimension(pair_count), target :: points_1,points_2,points_3
@@ -1077,9 +1078,10 @@ module mui_3d_f
     end subroutine mui_create_algorithm_fixed_relaxation_3f_f
 
     subroutine mui_create_algorithm_fixed_relaxation_3fx_f(algorithm, &
-        under_relaxation_factor,points_1,points_2,points_3,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,points_2,points_3,value_init,pair_count) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_float),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_float), intent(in), dimension(pair_count), target :: points_1,points_2,points_3
@@ -1087,9 +1089,10 @@ module mui_3d_f
     end subroutine mui_create_algorithm_fixed_relaxation_3fx_f
 
     subroutine mui_create_algorithm_fixed_relaxation_3d_f(algorithm, &
-        under_relaxation_factor,points_1,points_2,points_3,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,points_2,points_3,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1,points_2,points_3
@@ -1097,9 +1100,10 @@ module mui_3d_f
     end subroutine mui_create_algorithm_fixed_relaxation_3d_f
 
     subroutine mui_create_algorithm_fixed_relaxation_3dx_f(algorithm, &
-        under_relaxation_factor,points_1,points_2,points_3,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,points_2,points_3,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1,points_2,points_3
@@ -1107,9 +1111,10 @@ module mui_3d_f
     end subroutine mui_create_algorithm_fixed_relaxation_3dx_f
 
     subroutine mui_create_algorithm_fixed_relaxation_3t_f(algorithm, &
-        under_relaxation_factor,points_1,points_2,points_3,value_init,pair_count) bind(C)
+        under_relaxation_factor,communicator,points_1,points_2,points_3,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
+      type(c_ptr), intent(in), target :: communicator(*)
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1,points_2,points_3

--- a/wrappers/Python/mui4py/algorithms.py
+++ b/wrappers/Python/mui4py/algorithms.py
@@ -67,19 +67,34 @@ class Algorithm(CppClass):
 Algorithm.fetch_signature = algorithm_signature
 
 class AlgorithmFixedRelaxation(Algorithm):
-    def __init__(self, under_relaxation_factor=None, pts_value_init=None, config=None):
+    def __init__(self, under_relaxation_factor=None, local_comm=None, pts_value_init=None, config=None):
         if config is None:
             self.config=Config()
         else:
             self.config=config
         if pts_value_init is not None:
-            super(AlgorithmFixedRelaxation, self).__init__(config, args=(under_relaxation_factor, pts_value_init))
+            super(AlgorithmFixedRelaxation, self).__init__(config, args=(under_relaxation_factor, local_comm, pts_value_init))
         else:
-            if under_relaxation_factor is not None:
-                super(AlgorithmFixedRelaxation, self).__init__(config, args=(under_relaxation_factor,))
+            if local_comm is not None:
+                super(AlgorithmFixedRelaxation, self).__init__(config, args=(under_relaxation_factor, local_comm, []))
             else:
-                super(AlgorithmFixedRelaxation, self).__init__()
+                if under_relaxation_factor is not None:
+                    super(AlgorithmFixedRelaxation, self).__init__(config, args=(under_relaxation_factor, None, []))
+                else:
+                    super(AlgorithmFixedRelaxation, self).__init__(1.0, None, [])
         self._ALLOWED_IO_TYPES = [INT, INT32, INT64, UINT, UINT32, UINT64, FLOAT, FLOAT32, FLOAT64]
+
+    def get_under_relaxation_factor(self, t1, t2=None):
+        if t2 is not None:
+            return self.raw.get_under_relaxation_factor(t1, t2)
+        else:
+            return self.raw.get_under_relaxation_factor(t1)
+
+    def get_residual_L2_Norm(self, t1, t2=None):
+        if t2 is not None:
+            return self.raw.get_residual_L2_Norm(t1, t2)
+        else:
+            return self.raw.get_residual_L2_Norm(t1)
 
 class AlgorithmAitken(Algorithm):
     def __init__(self, under_relaxation_factor=None, under_relaxation_factor_max=None, local_comm=None, pts_vlu_init=None, res_l2_norm_nm1=None, config=None):

--- a/wrappers/Python/mui4py/cpp/algorithm.cpp
+++ b/wrappers/Python/mui4py/cpp/algorithm.cpp
@@ -53,12 +53,46 @@
 template <typename Tconfig>
 void declare_algorithms(py::module &m)
 {
-	std::string name = "_Algorithm_fixed_relaxation" + config_name<Tconfig>();
+    std::string name = "_Algorithm_fixed_relaxation" + config_name<Tconfig>();
     using TclassFR = mui::algo_fixed_relaxation<Tconfig>;
     using Treal = typename Tconfig::REAL;
     using Tpoint = typename Tconfig::point_type;
+    using Ttime = typename Tconfig::time_type;
+    using Titer = typename Tconfig::iterator_type;
     py::class_<TclassFR> algo_fixed_relaxation(m, name.c_str());
-    algo_fixed_relaxation.def(py::init<Treal, std::vector<std::pair<Tpoint, Treal>>>(), py::arg("under_relaxation_factor") = Treal(1.0), py::arg("pts_value_init") = std::vector<std::pair<Tpoint, Treal>>());
+    algo_fixed_relaxation.def(py::init([](Treal under_relaxation_factor = 1.0,
+                                pybind11::handle const& local_comm = py::none(),
+                                std::vector<std::pair<Tpoint, Treal>> pts_vlu_init = std::vector<std::pair<Tpoint, Treal>>()) {
+
+                // Import mpi4py if it does not exist.
+                if (!PyMPIComm_Get)
+                {
+                    if (import_mpi4py() < 0)
+                    {
+                        throw std::runtime_error(
+                            "MUI Error [wrappers/Python/mui4py/cpp/algorithm.cpp]: mpi4py not loaded correctly\n");
+                    }
+                }
+
+                MPI_Comm ric_mpiComm;
+
+                if (local_comm.is_none()) {
+                    MPI_Comm comm = MPI_COMM_NULL;
+                    ric_mpiComm = reinterpret_cast<MPI_Comm>(comm);
+                } else {
+                    PyObject *py_src = local_comm.ptr();
+                    MPI_Comm *comm_p = PyMPIComm_Get(py_src);
+                    ric_mpiComm = reinterpret_cast<MPI_Comm>(*comm_p);
+                }
+
+                return new mui::algo_fixed_relaxation<Tconfig>(under_relaxation_factor,
+                                                     ric_mpiComm,
+                                                     pts_vlu_init);
+    }))
+               .def("get_under_relaxation_factor", (Treal(TclassFR::*)(Ttime)) &TclassFR::get_under_relaxation_factor, "")
+               .def("get_under_relaxation_factor", (Treal(TclassFR::*)(Ttime, Titer)) &TclassFR::get_under_relaxation_factor, "")
+               .def("get_residual_L2_Norm", (Treal(TclassFR::*)(Ttime)) &TclassFR::get_residual_L2_Norm, "")
+               .def("get_residual_L2_Norm", (Treal(TclassFR::*)(Ttime, Titer)) &TclassFR::get_residual_L2_Norm, "");
 
     name = "_Algorithm_aitken" + config_name<Tconfig>();
     using TclassAitken = mui::algo_aitken<Tconfig>;
@@ -68,37 +102,37 @@ void declare_algorithms(py::module &m)
     using Titer = typename Tconfig::iterator_type;
     py::class_<TclassAitken> algo_aitken(m, name.c_str());
     algo_aitken.def(py::init([](Treal under_relaxation_factor = 1.0,
-    		    		    	Treal under_relaxation_factor_max = 1.0,
-								pybind11::handle const& local_comm = py::none(),
-								std::vector<std::pair<Tpoint, Treal>> pts_vlu_init = std::vector<std::pair<Tpoint, Treal>>(),
-								Treal res_l2_norm_nm1 = 0.0) {
+                                Treal under_relaxation_factor_max = 1.0,
+                                pybind11::handle const& local_comm = py::none(),
+                                std::vector<std::pair<Tpoint, Treal>> pts_vlu_init = std::vector<std::pair<Tpoint, Treal>>(),
+                                Treal res_l2_norm_nm1 = 0.0) {
 
-				// Import mpi4py if it does not exist.
-				if (!PyMPIComm_Get)
-				{
-					if (import_mpi4py() < 0)
-					{
-						throw std::runtime_error(
-							"MUI Error [wrappers/Python/mui4py/cpp/algorithm.cpp]: mpi4py not loaded correctly\n");
-					}
-				}
+                // Import mpi4py if it does not exist.
+                if (!PyMPIComm_Get)
+                {
+                    if (import_mpi4py() < 0)
+                    {
+                        throw std::runtime_error(
+                            "MUI Error [wrappers/Python/mui4py/cpp/algorithm.cpp]: mpi4py not loaded correctly\n");
+                    }
+                }
 
-				MPI_Comm ric_mpiComm;
+                MPI_Comm ric_mpiComm;
 
-				if (local_comm.is_none()) {
-					MPI_Comm comm = MPI_COMM_NULL;
-					ric_mpiComm = reinterpret_cast<MPI_Comm>(comm);
-				} else {
-					PyObject *py_src = local_comm.ptr();
-					MPI_Comm *comm_p = PyMPIComm_Get(py_src);
-					ric_mpiComm = reinterpret_cast<MPI_Comm>(*comm_p);
-				}
+                if (local_comm.is_none()) {
+                    MPI_Comm comm = MPI_COMM_NULL;
+                    ric_mpiComm = reinterpret_cast<MPI_Comm>(comm);
+                } else {
+                    PyObject *py_src = local_comm.ptr();
+                    MPI_Comm *comm_p = PyMPIComm_Get(py_src);
+                    ric_mpiComm = reinterpret_cast<MPI_Comm>(*comm_p);
+                }
 
                 return new mui::algo_aitken<Tconfig>(under_relaxation_factor,
-                									 under_relaxation_factor_max,
-													 ric_mpiComm,
-													 pts_vlu_init,
-													 res_l2_norm_nm1);
+                                                     under_relaxation_factor_max,
+                                                     ric_mpiComm,
+                                                     pts_vlu_init,
+                                                     res_l2_norm_nm1);
     }))
                .def("get_under_relaxation_factor", (Treal(TclassAitken::*)(Ttime)) &TclassAitken::get_under_relaxation_factor, "")
                .def("get_under_relaxation_factor", (Treal(TclassAitken::*)(Ttime, Titer)) &TclassAitken::get_under_relaxation_factor, "")
@@ -109,19 +143,19 @@ void declare_algorithms(py::module &m)
 void algorithm(py::module &m)
 {
 #ifdef PYTHON_INT_64
-	declare_algorithms<mui::mui_config_1dx>(m);
-	declare_algorithms<mui::mui_config_2dx>(m);
-	declare_algorithms<mui::mui_config_3dx>(m);
-	declare_algorithms<mui::mui_config_1fx>(m);
-	declare_algorithms<mui::mui_config_2fx>(m);
-	declare_algorithms<mui::mui_config_3fx>(m);
+    declare_algorithms<mui::mui_config_1dx>(m);
+    declare_algorithms<mui::mui_config_2dx>(m);
+    declare_algorithms<mui::mui_config_3dx>(m);
+    declare_algorithms<mui::mui_config_1fx>(m);
+    declare_algorithms<mui::mui_config_2fx>(m);
+    declare_algorithms<mui::mui_config_3fx>(m);
 #elif defined PYTHON_INT_32
-	declare_algorithms<mui::mui_config_1d>(m);
-	declare_algorithms<mui::mui_config_2d>(m);
-	declare_algorithms<mui::mui_config_3d>(m);
-	declare_algorithms<mui::mui_config_1f>(m);
-	declare_algorithms<mui::mui_config_2f>(m);
-	declare_algorithms<mui::mui_config_3f>(m);
+    declare_algorithms<mui::mui_config_1d>(m);
+    declare_algorithms<mui::mui_config_2d>(m);
+    declare_algorithms<mui::mui_config_3d>(m);
+    declare_algorithms<mui::mui_config_1f>(m);
+    declare_algorithms<mui::mui_config_2f>(m);
+    declare_algorithms<mui::mui_config_3f>(m);
 #else
 #error PYTHON_INT_[32|64] not defined.
 #endif


### PR DESCRIPTION
## What has been done
- Updated C, Fortran and Python wrappers on the new Fixed Relaxation API (residual calculation functions).
- Implemented Fixed Relaxation get under relaxation factor and Fixed Relaxation get residual L2 norm function for C, Fortran and Python wrappers.
- Updated Changelog with newly implemented features.
## Demos
- Updated demos can be found in [v2.1 branch of Wendi Liu's personal MUI-demo fork](https://github.com/Wendi-L/MUI-demo/tree/v2.1). It will be pushed to the MUI-demo official repository with the upcoming MUI v2.1 release.  