### PR TITLE
Update the method of creating Fortran communicator

### DIFF
--- a/wrappers/Fortran/mui_f_wrapper_1d.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_1d.cpp
@@ -700,7 +700,7 @@ void mui_create_sampler_sum_quintic_1t_f(mui_sampler_sum_quintic_1t** ret, doubl
 // Radial Basis Function sampler
 void mui_create_sampler_rbf_1f_f(mui_sampler_rbf_1f **ret, float* r, float* points_1, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address,
-        float* cutoff, float* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+        float* cutoff, float* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::point1f> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = points_1[i];
@@ -708,12 +708,12 @@ void mui_create_sampler_rbf_1f_f(mui_sampler_rbf_1f **ret, float* r, float* poin
 
     *ret = new mui_sampler_rbf_1f(*r, pts, *basis_func, static_cast<bool>(*conservative),
             static_cast<bool>(*smoothFunc), static_cast<bool>(*writeMatrix), std::string(file_address),
-            *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, reinterpret_cast<MPI_Comm>(*communicator));
+            *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, MPI_Comm_f2c(*communicator));
 }
 
 void mui_create_sampler_rbf_1fx_f(mui_sampler_rbf_1fx **ret, float* r, float* points_1, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address,
-        float* cutoff, float* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+        float* cutoff, float* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::point1fx> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = points_1[i];
@@ -721,12 +721,12 @@ void mui_create_sampler_rbf_1fx_f(mui_sampler_rbf_1fx **ret, float* r, float* po
 
     *ret = new mui_sampler_rbf_1fx(*r, pts, *basis_func, static_cast<bool>(*conservative),
             static_cast<bool>(*smoothFunc), static_cast<bool>(*writeMatrix), std::string(file_address),
-            *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, reinterpret_cast<MPI_Comm>(*communicator));
+            *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, MPI_Comm_f2c(*communicator));
 }
 
 void mui_create_sampler_rbf_1d_f(mui_sampler_rbf_1d **ret, double* r, double* points_1, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address,
-        double* cutoff, double* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+        double* cutoff, double* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::point1d> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = points_1[i];
@@ -734,12 +734,12 @@ void mui_create_sampler_rbf_1d_f(mui_sampler_rbf_1d **ret, double* r, double* po
 
     *ret = new mui_sampler_rbf_1d(*r, pts, *basis_func, static_cast<bool>(*conservative),
             static_cast<bool>(*smoothFunc), static_cast<bool>(*writeMatrix), std::string(file_address),
-            *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, reinterpret_cast<MPI_Comm>(*communicator));
+            *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, MPI_Comm_f2c(*communicator));
 }
 
 void mui_create_sampler_rbf_1dx_f(mui_sampler_rbf_1dx** ret, double* r, double* points_1, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address,
-        double* cutoff, double* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+        double* cutoff, double* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::point1dx> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = points_1[i];
@@ -747,12 +747,12 @@ void mui_create_sampler_rbf_1dx_f(mui_sampler_rbf_1dx** ret, double* r, double* 
 
     *ret = new mui_sampler_rbf_1dx(*r, pts, *basis_func, static_cast<bool>(*conservative),
             static_cast<bool>(*smoothFunc), static_cast<bool>(*writeMatrix), std::string(file_address),
-            *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, reinterpret_cast<MPI_Comm>(*communicator));
+            *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, MPI_Comm_f2c(*communicator));
 }
 
 void mui_create_sampler_rbf_1t_f(mui_sampler_rbf_1t** ret, double* r, double* points_1, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address,
-        double* cutoff, double* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+        double* cutoff, double* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::mui_f_wrapper_1D::point_type> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = static_cast<mui::mui_f_wrapper_1D::REAL>(points_1[i]);
@@ -763,7 +763,7 @@ void mui_create_sampler_rbf_1t_f(mui_sampler_rbf_1t** ret, double* r, double* po
             static_cast<bool>(*writeMatrix), std::string(file_address),
             static_cast<mui::mui_f_wrapper_1D::REAL>(*cutoff), static_cast<mui::mui_f_wrapper_1D::REAL>(*cg_solve_tol),
       static_cast<mui::mui_f_wrapper_1D::INT>(*cg_solve_it), static_cast<mui::mui_f_wrapper_1D::INT>(*pou_size),
-	  static_cast<mui::mui_f_wrapper_1D::INT>(*precond), reinterpret_cast<MPI_Comm>(*communicator));
+	  static_cast<mui::mui_f_wrapper_1D::INT>(*precond), MPI_Comm_f2c(*communicator));
 }
 
 /*******************************************
@@ -1163,7 +1163,7 @@ void mui_destroy_temporal_sampler_sum_1t_f(mui_temporal_sampler_sum_1t* sampler)
  *******************************************/
 
 // Fixed relaxation algorithm
-void mui_create_algorithm_fixed_relaxation_1f_f(mui_algorithm_fixed_relaxation_1f **ret, float* under_relaxation_factor, MPI_Comm* communicator, float* points_1, float* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_1f_f(mui_algorithm_fixed_relaxation_1f **ret, float* under_relaxation_factor, MPI_Fint* communicator, float* points_1, float* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point1f, float>> pts_value_init;
 
@@ -1178,10 +1178,10 @@ void mui_create_algorithm_fixed_relaxation_1f_f(mui_algorithm_fixed_relaxation_1
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_1f(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_1f(*under_relaxation_factor, MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_1fx_f(mui_algorithm_fixed_relaxation_1fx **ret, float* under_relaxation_factor, MPI_Comm* communicator, float* points_1, float* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_1fx_f(mui_algorithm_fixed_relaxation_1fx **ret, float* under_relaxation_factor, MPI_Fint* communicator, float* points_1, float* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point1fx, float>> pts_value_init;
 
@@ -1196,10 +1196,10 @@ void mui_create_algorithm_fixed_relaxation_1fx_f(mui_algorithm_fixed_relaxation_
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_1fx(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_1fx(*under_relaxation_factor, MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_1d_f(mui_algorithm_fixed_relaxation_1d **ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_1d_f(mui_algorithm_fixed_relaxation_1d **ret, double* under_relaxation_factor, MPI_Fint* communicator, double* points_1, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point1d, double>> pts_value_init;
 
@@ -1214,10 +1214,10 @@ void mui_create_algorithm_fixed_relaxation_1d_f(mui_algorithm_fixed_relaxation_1
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_1d(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_1d(*under_relaxation_factor, MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_1dx_f(mui_algorithm_fixed_relaxation_1dx** ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_1dx_f(mui_algorithm_fixed_relaxation_1dx** ret, double* under_relaxation_factor, MPI_Fint* communicator, double* points_1, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point1dx, double>> pts_value_init;
 
@@ -1232,10 +1232,10 @@ void mui_create_algorithm_fixed_relaxation_1dx_f(mui_algorithm_fixed_relaxation_
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_1dx(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_1dx(*under_relaxation_factor, MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_1t_f(mui_algorithm_fixed_relaxation_1t** ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_1t_f(mui_algorithm_fixed_relaxation_1t** ret, double* under_relaxation_factor, MPI_Fint* communicator, double* points_1, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::mui_f_wrapper_1D::point_type, mui::mui_f_wrapper_1D::REAL>> pts_value_init;
 
@@ -1250,11 +1250,11 @@ void mui_create_algorithm_fixed_relaxation_1t_f(mui_algorithm_fixed_relaxation_1
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_1t(static_cast<mui::mui_f_wrapper_1D::REAL>(*under_relaxation_factor), reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_1t(static_cast<mui::mui_f_wrapper_1D::REAL>(*under_relaxation_factor), MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
 // Aitken's algorithm
-void mui_create_algorithm_aitken_1f_f(mui_algorithm_aitken_1f **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Comm* communicator, float* points_1, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_1f_f(mui_algorithm_aitken_1f **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Fint* communicator, float* points_1, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::point1f, float>> pts_value_init;
 
@@ -1269,10 +1269,10 @@ void mui_create_algorithm_aitken_1f_f(mui_algorithm_aitken_1f **ret, float* unde
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_1f(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+    *ret = new mui_algorithm_aitken_1f(*under_relaxation_factor, *under_relaxation_factor_max, MPI_Comm_f2c(*communicator), pts_value_init, *res_l2_norm_nm1);
 }
 
-void mui_create_algorithm_aitken_1fx_f(mui_algorithm_aitken_1fx **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Comm* communicator, float* points_1, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_1fx_f(mui_algorithm_aitken_1fx **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Fint* communicator, float* points_1, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::point1fx, float>> pts_value_init;
 
@@ -1287,10 +1287,10 @@ void mui_create_algorithm_aitken_1fx_f(mui_algorithm_aitken_1fx **ret, float* un
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_1fx(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+    *ret = new mui_algorithm_aitken_1fx(*under_relaxation_factor, *under_relaxation_factor_max, MPI_Comm_f2c(*communicator), pts_value_init, *res_l2_norm_nm1);
 }
 
-void mui_create_algorithm_aitken_1d_f(mui_algorithm_aitken_1d **ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Comm* communicator, double* points_1, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_1d_f(mui_algorithm_aitken_1d **ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Fint* communicator, double* points_1, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::point1d, double>> pts_value_init;
 
@@ -1305,10 +1305,10 @@ void mui_create_algorithm_aitken_1d_f(mui_algorithm_aitken_1d **ret, double* und
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_1d(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+    *ret = new mui_algorithm_aitken_1d(*under_relaxation_factor, *under_relaxation_factor_max, MPI_Comm_f2c(*communicator), pts_value_init, *res_l2_norm_nm1);
 }
 
-void mui_create_algorithm_aitken_1dx_f(mui_algorithm_aitken_1dx** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Comm* communicator, double* points_1, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_1dx_f(mui_algorithm_aitken_1dx** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Fint* communicator, double* points_1, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::point1dx, double>> pts_value_init;
 
@@ -1323,10 +1323,10 @@ void mui_create_algorithm_aitken_1dx_f(mui_algorithm_aitken_1dx** ret, double* u
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_1dx(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+    *ret = new mui_algorithm_aitken_1dx(*under_relaxation_factor, *under_relaxation_factor_max, MPI_Comm_f2c(*communicator), pts_value_init, *res_l2_norm_nm1);
 }
 
-void mui_create_algorithm_aitken_1t_f(mui_algorithm_aitken_1t** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Comm* communicator, double* points_1, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_1t_f(mui_algorithm_aitken_1t** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Fint* communicator, double* points_1, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::mui_f_wrapper_1D::point_type, mui::mui_f_wrapper_1D::REAL>> pts_value_init;
 
@@ -1341,7 +1341,7 @@ void mui_create_algorithm_aitken_1t_f(mui_algorithm_aitken_1t** ret, double* und
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_1t(static_cast<mui::mui_f_wrapper_1D::REAL>(*under_relaxation_factor), static_cast<mui::mui_f_wrapper_1D::REAL>(*under_relaxation_factor_max), reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, static_cast<mui::mui_f_wrapper_1D::REAL>(*res_l2_norm_nm1));
+    *ret = new mui_algorithm_aitken_1t(static_cast<mui::mui_f_wrapper_1D::REAL>(*under_relaxation_factor), static_cast<mui::mui_f_wrapper_1D::REAL>(*under_relaxation_factor_max), MPI_Comm_f2c(*communicator), pts_value_init, static_cast<mui::mui_f_wrapper_1D::REAL>(*res_l2_norm_nm1));
 }
 
 /*******************************************

--- a/wrappers/Fortran/mui_f_wrapper_1d.f90
+++ b/wrappers/Fortran/mui_f_wrapper_1d.f90
@@ -522,7 +522,7 @@ module mui_1d_f
             conservative,smoothFunc,writeMatrix,cgSolveIt,pouSize,precond
       real(kind=c_float), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_float), intent(in), dimension(points_count), target :: points_1
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_1f_f
 
     subroutine mui_create_sampler_rbf_1fx_f(sampler,r,points_1,points_count, &
@@ -536,7 +536,7 @@ module mui_1d_f
             conservative,smoothFunc,writeMatrix,cgSolveIt,pouSize,precond
       real(kind=c_float), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_float), intent(in), dimension(points_count), target :: points_1
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_1fx_f
 
     subroutine mui_create_sampler_rbf_1d_f(sampler,r,points_1,points_count, &
@@ -550,7 +550,7 @@ module mui_1d_f
             conservative,smoothFunc,writeMatrix,cgSolveIt,pouSize,precond
       real(kind=c_double), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_double), intent(in), dimension(points_count), target :: points_1
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_1d_f
 
     subroutine mui_create_sampler_rbf_1dx_f(sampler,r,points_1,points_count, &
@@ -564,7 +564,7 @@ module mui_1d_f
             conservative,smoothFunc,writeMatrix,cgSolveIt,pouSize,precond
       real(kind=c_double), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_double), intent(in), dimension(points_count), target :: points_1
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_1dx_f
 
     subroutine mui_create_sampler_rbf_1t_f(sampler,r,points_1,points_count, &
@@ -578,7 +578,7 @@ module mui_1d_f
          conservative,smoothFunc,writeMatrix,cgSolveIt,pouSize,precond
       real(kind=c_double), intent(in), target :: r,cutoff,cgSolveTol
       real(c_double), intent(in), dimension(points_count), target :: points_1
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_1t_f
 
     !******************************************
@@ -1090,7 +1090,7 @@ module mui_1d_f
         under_relaxation_factor,communicator,points_1,value_init,pair_count) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_float),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_float), intent(in), dimension(pair_count), target :: points_1
@@ -1101,7 +1101,7 @@ module mui_1d_f
         under_relaxation_factor,communicator,points_1,value_init,pair_count) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_float),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_float), intent(in), dimension(pair_count), target :: points_1
@@ -1112,7 +1112,7 @@ module mui_1d_f
         under_relaxation_factor,communicator,points_1,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1
@@ -1123,7 +1123,7 @@ module mui_1d_f
         under_relaxation_factor,communicator,points_1,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1
@@ -1134,7 +1134,7 @@ module mui_1d_f
         under_relaxation_factor,communicator,points_1,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1
@@ -1147,7 +1147,7 @@ module mui_1d_f
         communicator,points_1,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_float),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count
@@ -1160,7 +1160,7 @@ module mui_1d_f
         points_1,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_float),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count
@@ -1173,7 +1173,7 @@ module mui_1d_f
         points_1,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count
@@ -1186,7 +1186,7 @@ module mui_1d_f
         points_1,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count
@@ -1199,7 +1199,7 @@ module mui_1d_f
         points_1,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count

--- a/wrappers/Fortran/mui_f_wrapper_2d.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_2d.cpp
@@ -700,7 +700,7 @@ void mui_create_sampler_sum_quintic_2t_f(mui_sampler_sum_quintic_2t** ret, doubl
 // Radial Basis Function sampler
 void mui_create_sampler_rbf_2f_f(mui_sampler_rbf_2f **ret, float* r, float* points_1, float* points_2, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address,
-    float* cutoff, float* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+    float* cutoff, float* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::point2f> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = points_1[i];
@@ -709,12 +709,12 @@ void mui_create_sampler_rbf_2f_f(mui_sampler_rbf_2f **ret, float* r, float* poin
 
     *ret = new mui_sampler_rbf_2f(*r, pts, *basis_func, static_cast<bool>(*conservative),
       static_cast<bool>(*smoothFunc), static_cast<bool>(*writeMatrix), std::string(file_address),
-      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, reinterpret_cast<MPI_Comm>(*communicator));
+      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, MPI_Comm_f2c(*communicator));
 }
 
 void mui_create_sampler_rbf_2fx_f(mui_sampler_rbf_2fx **ret, float* r, float* points_1, float* points_2, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address,
-    float* cutoff, float* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+    float* cutoff, float* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::point2fx> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = points_1[i];
@@ -723,12 +723,12 @@ void mui_create_sampler_rbf_2fx_f(mui_sampler_rbf_2fx **ret, float* r, float* po
 
     *ret = new mui_sampler_rbf_2fx(*r, pts, *basis_func, static_cast<bool>(*conservative),
       static_cast<bool>(*smoothFunc), static_cast<bool>(*writeMatrix), std::string(file_address),
-      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, reinterpret_cast<MPI_Comm>(*communicator));
+      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, MPI_Comm_f2c(*communicator));
 }
 
 void mui_create_sampler_rbf_2d_f(mui_sampler_rbf_2d **ret, double* r, double* points_1, double* points_2, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address,
-        double* cutoff, double* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+        double* cutoff, double* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::point2d> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = points_1[i];
@@ -737,12 +737,12 @@ void mui_create_sampler_rbf_2d_f(mui_sampler_rbf_2d **ret, double* r, double* po
 
     *ret = new mui_sampler_rbf_2d(*r, pts, *basis_func, static_cast<bool>(*conservative),
       static_cast<bool>(*smoothFunc), static_cast<bool>(*writeMatrix), std::string(file_address),
-      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, reinterpret_cast<MPI_Comm>(*communicator));
+      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, MPI_Comm_f2c(*communicator));
 }
 
 void mui_create_sampler_rbf_2dx_f(mui_sampler_rbf_2dx** ret, double* r, double* points_1, double* points_2, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address,
-        double* cutoff, double* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+        double* cutoff, double* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::point2dx> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = points_1[i];
@@ -751,12 +751,12 @@ void mui_create_sampler_rbf_2dx_f(mui_sampler_rbf_2dx** ret, double* r, double* 
 
     *ret = new mui_sampler_rbf_2dx(*r, pts, *basis_func, static_cast<bool>(*conservative),
       static_cast<bool>(*smoothFunc), static_cast<bool>(*writeMatrix), std::string(file_address),
-      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, reinterpret_cast<MPI_Comm>(*communicator));
+      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, MPI_Comm_f2c(*communicator));
 }
 
 void mui_create_sampler_rbf_2t_f(mui_sampler_rbf_2t** ret, double* r, double* points_1, double* points_2, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc,int* writeMatrix, const char* file_address,
-        double* cutoff, double* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+        double* cutoff, double* cg_solve_tol, int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::mui_f_wrapper_2D::point_type> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = static_cast<mui::mui_f_wrapper_2D::REAL>(points_1[i]);
@@ -768,7 +768,7 @@ void mui_create_sampler_rbf_2t_f(mui_sampler_rbf_2t** ret, double* r, double* po
       static_cast<bool>(*writeMatrix), std::string(file_address),
       static_cast<mui::mui_f_wrapper_2D::REAL>(*cutoff), static_cast<mui::mui_f_wrapper_2D::REAL>(*cg_solve_tol),
       static_cast<mui::mui_f_wrapper_2D::INT>(*cg_solve_it), static_cast<mui::mui_f_wrapper_2D::INT>(*pou_size),
-	  static_cast<mui::mui_f_wrapper_2D::INT>(*precond), reinterpret_cast<MPI_Comm>(*communicator));
+	  static_cast<mui::mui_f_wrapper_2D::INT>(*precond), MPI_Comm_f2c(*communicator));
 }
 
 /*******************************************
@@ -1168,7 +1168,7 @@ void mui_destroy_temporal_sampler_sum_2t_f(mui_temporal_sampler_sum_2t* sampler)
  *******************************************/
 
 // Fixed relaxation algorithm
-void mui_create_algorithm_fixed_relaxation_2f_f(mui_algorithm_fixed_relaxation_2f **ret, float* under_relaxation_factor, MPI_Comm* communicator, float* points_1, float* points_2, float* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_2f_f(mui_algorithm_fixed_relaxation_2f **ret, float* under_relaxation_factor, MPI_Fint* communicator, float* points_1, float* points_2, float* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point2f, float>> pts_value_init;
 
@@ -1184,10 +1184,10 @@ void mui_create_algorithm_fixed_relaxation_2f_f(mui_algorithm_fixed_relaxation_2
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_2f(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_2f(*under_relaxation_factor, MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_2fx_f(mui_algorithm_fixed_relaxation_2fx **ret, float* under_relaxation_factor, MPI_Comm* communicator, float* points_1, float* points_2, float* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_2fx_f(mui_algorithm_fixed_relaxation_2fx **ret, float* under_relaxation_factor, MPI_Fint* communicator, float* points_1, float* points_2, float* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point2fx, float>> pts_value_init;
 
@@ -1203,10 +1203,10 @@ void mui_create_algorithm_fixed_relaxation_2fx_f(mui_algorithm_fixed_relaxation_
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_2fx(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_2fx(*under_relaxation_factor, MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_2d_f(mui_algorithm_fixed_relaxation_2d **ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* points_2, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_2d_f(mui_algorithm_fixed_relaxation_2d **ret, double* under_relaxation_factor, MPI_Fint* communicator, double* points_1, double* points_2, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point2d, double>> pts_value_init;
 
@@ -1222,10 +1222,10 @@ void mui_create_algorithm_fixed_relaxation_2d_f(mui_algorithm_fixed_relaxation_2
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_2d(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_2d(*under_relaxation_factor, MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_2dx_f(mui_algorithm_fixed_relaxation_2dx** ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* points_2, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_2dx_f(mui_algorithm_fixed_relaxation_2dx** ret, double* under_relaxation_factor, MPI_Fint* communicator, double* points_1, double* points_2, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point2dx, double>> pts_value_init;
 
@@ -1241,10 +1241,10 @@ void mui_create_algorithm_fixed_relaxation_2dx_f(mui_algorithm_fixed_relaxation_
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_2dx(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_2dx(*under_relaxation_factor, MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_2t_f(mui_algorithm_fixed_relaxation_2t** ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* points_2, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_2t_f(mui_algorithm_fixed_relaxation_2t** ret, double* under_relaxation_factor, MPI_Fint* communicator, double* points_1, double* points_2, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::mui_f_wrapper_2D::point_type, mui::mui_f_wrapper_2D::REAL>> pts_value_init;
 
@@ -1260,11 +1260,11 @@ void mui_create_algorithm_fixed_relaxation_2t_f(mui_algorithm_fixed_relaxation_2
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_2t(static_cast<mui::mui_f_wrapper_2D::REAL>(*under_relaxation_factor), reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_2t(static_cast<mui::mui_f_wrapper_2D::REAL>(*under_relaxation_factor), MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
 // Aitken's algorithm
-void mui_create_algorithm_aitken_2f_f(mui_algorithm_aitken_2f **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Comm* communicator, float* points_1, float* points_2, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_2f_f(mui_algorithm_aitken_2f **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Fint* communicator, float* points_1, float* points_2, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::point2f, float>> pts_value_init;
 
@@ -1280,10 +1280,10 @@ void mui_create_algorithm_aitken_2f_f(mui_algorithm_aitken_2f **ret, float* unde
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_2f(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+    *ret = new mui_algorithm_aitken_2f(*under_relaxation_factor, *under_relaxation_factor_max, MPI_Comm_f2c(*communicator), pts_value_init, *res_l2_norm_nm1);
 }
 
-void mui_create_algorithm_aitken_2fx_f(mui_algorithm_aitken_2fx **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Comm* communicator, float* points_1, float* points_2, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_2fx_f(mui_algorithm_aitken_2fx **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Fint* communicator, float* points_1, float* points_2, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::point2fx, float>> pts_value_init;
 
@@ -1299,10 +1299,10 @@ void mui_create_algorithm_aitken_2fx_f(mui_algorithm_aitken_2fx **ret, float* un
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_2fx(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+    *ret = new mui_algorithm_aitken_2fx(*under_relaxation_factor, *under_relaxation_factor_max, MPI_Comm_f2c(*communicator), pts_value_init, *res_l2_norm_nm1);
 }
 
-void mui_create_algorithm_aitken_2d_f(mui_algorithm_aitken_2d **ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Comm* communicator, double* points_1, double* points_2, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_2d_f(mui_algorithm_aitken_2d **ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Fint* communicator, double* points_1, double* points_2, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::point2d, double>> pts_value_init;
 
@@ -1318,10 +1318,10 @@ void mui_create_algorithm_aitken_2d_f(mui_algorithm_aitken_2d **ret, double* und
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_2d(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+    *ret = new mui_algorithm_aitken_2d(*under_relaxation_factor, *under_relaxation_factor_max, MPI_Comm_f2c(*communicator), pts_value_init, *res_l2_norm_nm1);
 }
 
-void mui_create_algorithm_aitken_2dx_f(mui_algorithm_aitken_2dx** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Comm* communicator, double* points_1, double* points_2, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_2dx_f(mui_algorithm_aitken_2dx** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Fint* communicator, double* points_1, double* points_2, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::point2dx, double>> pts_value_init;
 
@@ -1337,10 +1337,10 @@ void mui_create_algorithm_aitken_2dx_f(mui_algorithm_aitken_2dx** ret, double* u
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_2dx(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+    *ret = new mui_algorithm_aitken_2dx(*under_relaxation_factor, *under_relaxation_factor_max, MPI_Comm_f2c(*communicator), pts_value_init, *res_l2_norm_nm1);
 }
 
-void mui_create_algorithm_aitken_2t_f(mui_algorithm_aitken_2t** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Comm* communicator, double* points_1, double* points_2, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_2t_f(mui_algorithm_aitken_2t** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Fint* communicator, double* points_1, double* points_2, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::mui_f_wrapper_2D::point_type, mui::mui_f_wrapper_2D::REAL>> pts_value_init;
 
@@ -1356,7 +1356,7 @@ void mui_create_algorithm_aitken_2t_f(mui_algorithm_aitken_2t** ret, double* und
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_2t(static_cast<mui::mui_f_wrapper_2D::REAL>(*under_relaxation_factor), static_cast<mui::mui_f_wrapper_2D::REAL>(*under_relaxation_factor_max), reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, static_cast<mui::mui_f_wrapper_2D::REAL>(*res_l2_norm_nm1));
+    *ret = new mui_algorithm_aitken_2t(static_cast<mui::mui_f_wrapper_2D::REAL>(*under_relaxation_factor), static_cast<mui::mui_f_wrapper_2D::REAL>(*under_relaxation_factor_max), MPI_Comm_f2c(*communicator), pts_value_init, static_cast<mui::mui_f_wrapper_2D::REAL>(*res_l2_norm_nm1));
 }
 
 /*******************************************

--- a/wrappers/Fortran/mui_f_wrapper_2d.f90
+++ b/wrappers/Fortran/mui_f_wrapper_2d.f90
@@ -510,7 +510,7 @@ module mui_2d_f
       pouSize,precond
       real(kind=c_float), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_float), intent(in), dimension(points_count), target :: points_1,points_2
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_2f_f
 
     subroutine mui_create_sampler_rbf_2fx_f(sampler,r,points_1,points_2,points_count,basis_func,conservative,smoothFunc, &
@@ -522,7 +522,7 @@ module mui_2d_f
       pouSize,precond
       real(kind=c_float), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_float), intent(in), dimension(points_count), target :: points_1,points_2
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_2fx_f
 
     subroutine mui_create_sampler_rbf_2d_f(sampler,r,points_1,points_2,points_count,basis_func,conservative,smoothFunc, &
@@ -534,7 +534,7 @@ module mui_2d_f
       pouSize,precond
       real(kind=c_double), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_double), intent(in), dimension(points_count), target :: points_1,points_2
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_2d_f
 
     subroutine mui_create_sampler_rbf_2dx_f(sampler,r,points_1,points_2,points_count,basis_func,conservative,smoothFunc, &
@@ -546,7 +546,7 @@ module mui_2d_f
       pouSize,precond
       real(kind=c_double), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_double), intent(in), dimension(points_count), target :: points_1,points_2
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_2dx_f
 
     subroutine mui_create_sampler_rbf_2t_f(sampler,r,points_1,points_2,points_count,basis_func,conservative,smoothFunc, &
@@ -558,7 +558,7 @@ module mui_2d_f
       pouSize,precond
       real(kind=c_double), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_double), intent(in), dimension(points_count), target :: points_1,points_2
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_2t_f
 
     !******************************************
@@ -1070,7 +1070,7 @@ module mui_2d_f
         under_relaxation_factor,communicator,points_1,points_2,value_init,pair_count) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_float),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_float), intent(in), dimension(pair_count), target :: points_1,points_2
@@ -1081,7 +1081,7 @@ module mui_2d_f
         under_relaxation_factor,communicator,points_1,points_2,value_init,pair_count) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_float),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_float), intent(in), dimension(pair_count), target :: points_1,points_2
@@ -1092,7 +1092,7 @@ module mui_2d_f
         under_relaxation_factor,communicator,points_1,points_2,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1,points_2
@@ -1103,7 +1103,7 @@ module mui_2d_f
         under_relaxation_factor,communicator,points_1,points_2,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1,points_2
@@ -1114,7 +1114,7 @@ module mui_2d_f
         under_relaxation_factor,communicator,points_1,points_2,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1,points_2
@@ -1127,7 +1127,7 @@ module mui_2d_f
         communicator,points_1,points_2,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_float),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count
@@ -1140,7 +1140,7 @@ module mui_2d_f
         points_1,points_2,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_float),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count
@@ -1153,7 +1153,7 @@ module mui_2d_f
         points_1,points_2,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count
@@ -1166,7 +1166,7 @@ module mui_2d_f
         points_1,points_2,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count
@@ -1179,7 +1179,7 @@ module mui_2d_f
         points_1,points_2,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count

--- a/wrappers/Fortran/mui_f_wrapper_3d.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_3d.cpp
@@ -700,7 +700,7 @@ void mui_create_sampler_sum_quintic_3t_f(mui_sampler_sum_quintic_3t** ret, doubl
 // Radial Basis Function sampler
 void mui_create_sampler_rbf_3f_f(mui_sampler_rbf_3f **ret, float* r, float* points_1, float* points_2, float* points_3, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address, float* cutoff, float* cg_solve_tol,
-        int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+        int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::point3f> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = points_1[i];
@@ -710,12 +710,12 @@ void mui_create_sampler_rbf_3f_f(mui_sampler_rbf_3f **ret, float* r, float* poin
 
     *ret = new mui_sampler_rbf_3f(*r, pts, *basis_func, static_cast<bool>(*conservative),
       static_cast<bool>(*smoothFunc), static_cast<bool>(*writeMatrix), std::string(file_address),
-      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, reinterpret_cast<MPI_Comm>(*communicator));
+      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, MPI_Comm_f2c(*communicator));
 }
 
 void mui_create_sampler_rbf_3fx_f(mui_sampler_rbf_3fx **ret, float* r, float* points_1, float* points_2, float* points_3, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address, float* cutoff, float* cg_solve_tol,
-    int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+    int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::point3fx> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = points_1[i];
@@ -725,12 +725,12 @@ void mui_create_sampler_rbf_3fx_f(mui_sampler_rbf_3fx **ret, float* r, float* po
 
     *ret = new mui_sampler_rbf_3fx(*r, pts, *basis_func, static_cast<bool>(*conservative),
       static_cast<bool>(*smoothFunc), static_cast<bool>(*writeMatrix), std::string(file_address),
-      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, reinterpret_cast<MPI_Comm>(*communicator));
+      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, MPI_Comm_f2c(*communicator));
 }
 
 void mui_create_sampler_rbf_3d_f(mui_sampler_rbf_3d **ret, double* r, double* points_1, double* points_2, double* points_3, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address, double* cutoff, double* cg_solve_tol,
-    int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+    int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::point3d> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = points_1[i];
@@ -740,12 +740,12 @@ void mui_create_sampler_rbf_3d_f(mui_sampler_rbf_3d **ret, double* r, double* po
 
     *ret = new mui_sampler_rbf_3d(*r, pts, *basis_func, static_cast<bool>(*conservative),
       static_cast<bool>(*smoothFunc), static_cast<bool>(*writeMatrix), std::string(file_address),
-      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, reinterpret_cast<MPI_Comm>(*communicator));
+      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, MPI_Comm_f2c(*communicator));
 }
 
 void mui_create_sampler_rbf_3dx_f(mui_sampler_rbf_3dx** ret, double* r, double* points_1, double* points_2, double* points_3, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address, double* cutoff, double* cg_solve_tol,
-    int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+    int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::point3dx> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = points_1[i];
@@ -755,12 +755,12 @@ void mui_create_sampler_rbf_3dx_f(mui_sampler_rbf_3dx** ret, double* r, double* 
 
     *ret = new mui_sampler_rbf_3dx(*r, pts, *basis_func, static_cast<bool>(*conservative),
       static_cast<bool>(*smoothFunc), static_cast<bool>(*writeMatrix), std::string(file_address),
-      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, reinterpret_cast<MPI_Comm>(*communicator));
+      *cutoff, *cg_solve_tol, *cg_solve_it, *pou_size, *precond, MPI_Comm_f2c(*communicator));
 }
 
 void mui_create_sampler_rbf_3t_f(mui_sampler_rbf_3t** ret, double* r, double* points_1, double* points_2, double* points_3, int* points_count, int* basis_func,
         int* conservative, int* smoothFunc, int* writeMatrix, const char* file_address, double* cutoff, double* cg_solve_tol,
-    int* cg_solve_it, int* pou_size, int* precond, MPI_Comm* communicator) {
+    int* cg_solve_it, int* pou_size, int* precond, MPI_Fint* communicator) {
     std::vector<mui::mui_f_wrapper_3D::point_type> pts(*points_count);
     for (size_t i = 0; i < *points_count; i++) {
         pts[i][0] = static_cast<mui::mui_f_wrapper_3D::REAL>(points_1[i]);
@@ -773,7 +773,7 @@ void mui_create_sampler_rbf_3t_f(mui_sampler_rbf_3t** ret, double* r, double* po
       static_cast<bool>(*writeMatrix), std::string(file_address),
       static_cast<mui::mui_f_wrapper_3D::REAL>(*cutoff), static_cast<mui::mui_f_wrapper_3D::REAL>(*cg_solve_tol),
       static_cast<mui::mui_f_wrapper_3D::INT>(*cg_solve_it), static_cast<mui::mui_f_wrapper_3D::INT>(*pou_size),
-	  static_cast<mui::mui_f_wrapper_3D::INT>(*precond), reinterpret_cast<MPI_Comm>(*communicator));
+	  static_cast<mui::mui_f_wrapper_3D::INT>(*precond), MPI_Comm_f2c(*communicator));
 }
 
 /*******************************************
@@ -1173,7 +1173,7 @@ void mui_destroy_temporal_sampler_sum_3t_f(mui_temporal_sampler_sum_3t* sampler)
  *******************************************/
 
 // Fixed relaxation algorithm
-void mui_create_algorithm_fixed_relaxation_3f_f(mui_algorithm_fixed_relaxation_3f **ret, float* under_relaxation_factor, MPI_Comm* communicator, float* points_1, float* points_2, float* points_3, float* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_3f_f(mui_algorithm_fixed_relaxation_3f **ret, float* under_relaxation_factor, MPI_Fint* communicator, float* points_1, float* points_2, float* points_3, float* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point3f, float>> pts_value_init;
 
@@ -1190,10 +1190,10 @@ void mui_create_algorithm_fixed_relaxation_3f_f(mui_algorithm_fixed_relaxation_3
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_3f(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_3f(*under_relaxation_factor, MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_3fx_f(mui_algorithm_fixed_relaxation_3fx **ret, float* under_relaxation_factor, MPI_Comm* communicator, float* points_1, float* points_2, float* points_3, float* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_3fx_f(mui_algorithm_fixed_relaxation_3fx **ret, float* under_relaxation_factor, MPI_Fint* communicator, float* points_1, float* points_2, float* points_3, float* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point3fx, float>> pts_value_init;
 
@@ -1210,10 +1210,10 @@ void mui_create_algorithm_fixed_relaxation_3fx_f(mui_algorithm_fixed_relaxation_
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_3fx(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_3fx(*under_relaxation_factor, MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_3d_f(mui_algorithm_fixed_relaxation_3d **ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_3d_f(mui_algorithm_fixed_relaxation_3d **ret, double* under_relaxation_factor, MPI_Fint* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point3d, double>> pts_value_init;
 
@@ -1230,10 +1230,10 @@ void mui_create_algorithm_fixed_relaxation_3d_f(mui_algorithm_fixed_relaxation_3
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_3d(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_3d(*under_relaxation_factor, MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_3dx_f(mui_algorithm_fixed_relaxation_3dx** ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_3dx_f(mui_algorithm_fixed_relaxation_3dx** ret, double* under_relaxation_factor, MPI_Fint* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::point3dx, double>> pts_value_init;
 
@@ -1250,10 +1250,10 @@ void mui_create_algorithm_fixed_relaxation_3dx_f(mui_algorithm_fixed_relaxation_
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_3dx(*under_relaxation_factor, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_3dx(*under_relaxation_factor, MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
-void mui_create_algorithm_fixed_relaxation_3t_f(mui_algorithm_fixed_relaxation_3t** ret, double* under_relaxation_factor, MPI_Comm* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count) {
+void mui_create_algorithm_fixed_relaxation_3t_f(mui_algorithm_fixed_relaxation_3t** ret, double* under_relaxation_factor, MPI_Fint* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count) {
 
 	std::vector<std::pair<mui::mui_f_wrapper_3D::point_type, mui::mui_f_wrapper_3D::REAL>> pts_value_init;
 
@@ -1270,11 +1270,11 @@ void mui_create_algorithm_fixed_relaxation_3t_f(mui_algorithm_fixed_relaxation_3
 		}
 	}
 
-    *ret = new mui_algorithm_fixed_relaxation_3t(static_cast<mui::mui_f_wrapper_3D::REAL>(*under_relaxation_factor), reinterpret_cast<MPI_Comm>(*communicator), pts_value_init);
+    *ret = new mui_algorithm_fixed_relaxation_3t(static_cast<mui::mui_f_wrapper_3D::REAL>(*under_relaxation_factor), MPI_Comm_f2c(*communicator), pts_value_init);
 }
 
 // Aitken's algorithm
-void mui_create_algorithm_aitken_3f_f(mui_algorithm_aitken_3f **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Comm* communicator, float* points_1, float* points_2, float* points_3, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_3f_f(mui_algorithm_aitken_3f **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Fint* communicator, float* points_1, float* points_2, float* points_3, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::point3f, float>> pts_value_init;
 
@@ -1291,10 +1291,10 @@ void mui_create_algorithm_aitken_3f_f(mui_algorithm_aitken_3f **ret, float* unde
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_3f(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+    *ret = new mui_algorithm_aitken_3f(*under_relaxation_factor, *under_relaxation_factor_max, MPI_Comm_f2c(*communicator), pts_value_init, *res_l2_norm_nm1);
 }
 
-void mui_create_algorithm_aitken_3fx_f(mui_algorithm_aitken_3fx **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Comm* communicator, float* points_1, float* points_2, float* points_3, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_3fx_f(mui_algorithm_aitken_3fx **ret, float* under_relaxation_factor, float* under_relaxation_factor_max, MPI_Fint* communicator, float* points_1, float* points_2, float* points_3, float* value_init, int* pair_count, float* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::point3fx, float>> pts_value_init;
 
@@ -1311,10 +1311,10 @@ void mui_create_algorithm_aitken_3fx_f(mui_algorithm_aitken_3fx **ret, float* un
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_3fx(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+    *ret = new mui_algorithm_aitken_3fx(*under_relaxation_factor, *under_relaxation_factor_max, MPI_Comm_f2c(*communicator), pts_value_init, *res_l2_norm_nm1);
 }
 
-void mui_create_algorithm_aitken_3d_f(mui_algorithm_aitken_3d **ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Comm* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_3d_f(mui_algorithm_aitken_3d **ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Fint* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::point3d, double>> pts_value_init;
 
@@ -1331,10 +1331,10 @@ void mui_create_algorithm_aitken_3d_f(mui_algorithm_aitken_3d **ret, double* und
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_3d(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+    *ret = new mui_algorithm_aitken_3d(*under_relaxation_factor, *under_relaxation_factor_max, MPI_Comm_f2c(*communicator), pts_value_init, *res_l2_norm_nm1);
 }
 
-void mui_create_algorithm_aitken_3dx_f(mui_algorithm_aitken_3dx** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Comm* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_3dx_f(mui_algorithm_aitken_3dx** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Fint* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::point3dx, double>> pts_value_init;
 
@@ -1351,10 +1351,10 @@ void mui_create_algorithm_aitken_3dx_f(mui_algorithm_aitken_3dx** ret, double* u
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_3dx(*under_relaxation_factor, *under_relaxation_factor_max, reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, *res_l2_norm_nm1);
+    *ret = new mui_algorithm_aitken_3dx(*under_relaxation_factor, *under_relaxation_factor_max, MPI_Comm_f2c(*communicator), pts_value_init, *res_l2_norm_nm1);
 }
 
-void mui_create_algorithm_aitken_3t_f(mui_algorithm_aitken_3t** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Comm* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
+void mui_create_algorithm_aitken_3t_f(mui_algorithm_aitken_3t** ret, double* under_relaxation_factor, double* under_relaxation_factor_max, MPI_Fint* communicator, double* points_1, double* points_2, double* points_3, double* value_init, int* pair_count, double* res_l2_norm_nm1) {
 
 	std::vector<std::pair<mui::mui_f_wrapper_3D::point_type, mui::mui_f_wrapper_3D::REAL>> pts_value_init;
 
@@ -1371,7 +1371,7 @@ void mui_create_algorithm_aitken_3t_f(mui_algorithm_aitken_3t** ret, double* und
 		}
 	}
 
-    *ret = new mui_algorithm_aitken_3t(static_cast<mui::mui_f_wrapper_3D::REAL>(*under_relaxation_factor), static_cast<mui::mui_f_wrapper_3D::REAL>(*under_relaxation_factor_max), reinterpret_cast<MPI_Comm>(*communicator), pts_value_init, static_cast<mui::mui_f_wrapper_3D::REAL>(*res_l2_norm_nm1));
+    *ret = new mui_algorithm_aitken_3t(static_cast<mui::mui_f_wrapper_3D::REAL>(*under_relaxation_factor), static_cast<mui::mui_f_wrapper_3D::REAL>(*under_relaxation_factor_max), MPI_Comm_f2c(*communicator), pts_value_init, static_cast<mui::mui_f_wrapper_3D::REAL>(*res_l2_norm_nm1));
 }
 
 /*******************************************

--- a/wrappers/Fortran/mui_f_wrapper_3d.f90
+++ b/wrappers/Fortran/mui_f_wrapper_3d.f90
@@ -510,7 +510,7 @@ module mui_3d_f
       pouSize,precond
       real(kind=c_float), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_float), intent(in), dimension(points_count), target :: points_1,points_2,points_3
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_3f_f
 
     subroutine mui_create_sampler_rbf_3fx_f(sampler,r,points_1,points_2,points_3,points_count,basis_func,conservative,smoothFunc, &
@@ -522,7 +522,7 @@ module mui_3d_f
       pouSize,precond
       real(kind=c_float), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_float), intent(in), dimension(points_count), target :: points_1,points_2,points_3
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_3fx_f
 
     subroutine mui_create_sampler_rbf_3d_f(sampler,r,points_1,points_2,points_3,points_count,basis_func,conservative,smoothFunc, &
@@ -534,7 +534,7 @@ module mui_3d_f
       pouSize,precond
       real(kind=c_double), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_double), intent(in), dimension(points_count), target :: points_1,points_2,points_3
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_3d_f
 
     subroutine mui_create_sampler_rbf_3dx_f(sampler,r,points_1,points_2,points_3,points_count,basis_func,conservative,smoothFunc, &
@@ -546,7 +546,7 @@ module mui_3d_f
       pouSize,precond
       real(kind=c_double), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_double), intent(in), dimension(points_count), target :: points_1,points_2,points_3
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_3dx_f
 
     subroutine mui_create_sampler_rbf_3t_f(sampler,r,points_1,points_2,points_3,points_count,basis_func,conservative,smoothFunc, &
@@ -558,7 +558,7 @@ module mui_3d_f
       pouSize,precond
       real(kind=c_double), intent(in), target :: r,cutoff,cgSolveTol
       real(kind=c_double), intent(in), dimension(points_count), target :: points_1,points_2,points_3
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_create_sampler_rbf_3t_f
 
     !******************************************
@@ -1070,7 +1070,7 @@ module mui_3d_f
         under_relaxation_factor,communicator,points_1,points_2,points_3,value_init,pair_count) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_float),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_float), intent(in), dimension(pair_count), target :: points_1,points_2,points_3
@@ -1081,7 +1081,7 @@ module mui_3d_f
         under_relaxation_factor,communicator,points_1,points_2,points_3,value_init,pair_count) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_float),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_float), intent(in), dimension(pair_count), target :: points_1,points_2,points_3
@@ -1092,7 +1092,7 @@ module mui_3d_f
         under_relaxation_factor,communicator,points_1,points_2,points_3,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1,points_2,points_3
@@ -1103,7 +1103,7 @@ module mui_3d_f
         under_relaxation_factor,communicator,points_1,points_2,points_3,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1,points_2,points_3
@@ -1114,7 +1114,7 @@ module mui_3d_f
         under_relaxation_factor,communicator,points_1,points_2,points_3,value_init,pair_count) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor
       integer(kind=c_int), intent(in), target :: pair_count
       real(c_double), intent(in), dimension(pair_count), target :: points_1,points_2,points_3
@@ -1127,7 +1127,7 @@ module mui_3d_f
         communicator,points_1,points_2,points_3,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_float),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count
@@ -1140,7 +1140,7 @@ module mui_3d_f
         points_1,points_2,points_3,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_float,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_float),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count
@@ -1153,7 +1153,7 @@ module mui_3d_f
         points_1,points_2,points_3,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count
@@ -1166,7 +1166,7 @@ module mui_3d_f
         points_1,points_2,points_3,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count
@@ -1179,7 +1179,7 @@ module mui_3d_f
         points_1,points_2,points_3,value_init,pair_count,res_l2_norm_nm1) bind(C)
       import :: c_ptr,c_double,c_int
       type(c_ptr), intent(out), target :: algorithm
-      type(c_ptr), intent(in), target :: communicator(*)
+      integer(kind=c_int), intent(in), target :: communicator
       real(kind=c_double),intent(in) :: under_relaxation_factor, &
         under_relaxation_factor_max,res_l2_norm_nm1
       integer(kind=c_int), intent(in), target :: pair_count

--- a/wrappers/Fortran/mui_f_wrapper_general.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_general.cpp
@@ -52,22 +52,22 @@
 
 extern "C" {
 
-// Function to split MPI communicator and return new, local communicator
-void mui_mpi_split_by_app_f(MPI_Comm **communicator) {
-	*communicator = reinterpret_cast<MPI_Comm*>(mui::mpi_split_by_app());
+// Subroutine to split MPI communicator and return new, local communicator
+void mui_mpi_split_by_app_f(MPI_Fint *communicator) {
+	*communicator = MPI_Comm_c2f(mui::mpi_split_by_app());
 }
 
 // Function to split MPI communicator and return new, local communicator using threaded MPI init
-void mui_mpi_split_by_app_threaded_f(MPI_Comm **communicator, int *argc, char ***argv, int *threadType, int **thread_support) {
-	*communicator = reinterpret_cast<MPI_Comm*>(mui::mpi_split_by_app(*argc, *argv, *threadType, *thread_support));
+void mui_mpi_split_by_app_threaded_f(MPI_Fint *communicator, int *argc, char ***argv, int *threadType, int **thread_support) {
+	*communicator = MPI_Comm_c2f(mui::mpi_split_by_app(*argc, *argv, *threadType, *thread_support));
 }
 
-void mui_mpi_get_size_f(MPI_Comm *communicator, int *size) {
-	MPI_Comm_size(*communicator, size);
+void mui_mpi_get_size_f(MPI_Fint *communicator, int *size) {
+	MPI_Comm_size(MPI_Comm_f2c(*communicator), size);
 }
 
-void mui_mpi_get_rank_f(MPI_Comm *communicator, int *rank) {
-	MPI_Comm_rank(*communicator, rank);
+void mui_mpi_get_rank_f(MPI_Fint *communicator, int *rank) {
+	MPI_Comm_rank(MPI_Comm_f2c(*communicator), rank);
 }
 
 }

--- a/wrappers/Fortran/mui_f_wrapper_general.f90
+++ b/wrappers/Fortran/mui_f_wrapper_general.f90
@@ -53,32 +53,32 @@ module mui_general_f
   public
 
   interface
-    !Function to split MPI communicator and return new, local communicator
+    !Subroutine to split MPI communicator and return new, local communicator
     subroutine mui_mpi_split_by_app_f(communicator) bind(C)
-      import :: c_ptr
-      type(c_ptr), intent(out), target :: communicator
+      import :: c_int
+      integer(kind=c_int), intent(in), target :: communicator
     end subroutine mui_mpi_split_by_app_f
 
     !Function to split MPI communicator and return new, local communicator
     subroutine mui_mpi_split_by_app_threaded_f(communicator,argc,argv,threadType,thread_support) bind(C)
       import :: c_ptr,c_char,c_int
       type(c_ptr), intent(out), target :: thread_support
-      type(c_ptr), intent(out), target :: communicator
+      integer(kind=c_int), intent(in), target :: communicator
       integer(kind=c_int), intent(in) :: argc, threadType
       character(kind=c_char), intent(in), dimension(argc) :: argv(*)
     end subroutine mui_mpi_split_by_app_threaded_f
 
     !Function to get MPI size
     subroutine mui_mpi_get_size_f(communicator,local_size) bind(C)
-      import :: c_ptr,c_int
-      type(c_ptr), intent(out), target :: communicator
+      import :: c_int
+      integer(kind=c_int), intent(in), target :: communicator
       integer(kind=c_int), intent(in) :: local_size
     end subroutine mui_mpi_get_size_f
 
     !Function to get MPI rank
     subroutine mui_mpi_get_rank_f(communicator,local_rank) bind(C)
-      import :: c_ptr,c_int
-      type(c_ptr), intent(out), target :: communicator
+      import :: c_int
+      integer(kind=c_int), intent(in), target :: communicator
       integer(kind=c_int), intent(in) :: local_rank
     end subroutine mui_mpi_get_rank_f
 

--- a/wrappers/Fortran/unit_test_multi.f90
+++ b/wrappers/Fortran/unit_test_multi.f90
@@ -90,7 +90,7 @@ program main
   real(c_double) :: fetch_result_1d=-3_c_double
   real(c_double) :: fetch_result_2d=-3_c_double
   real(c_double) :: fetch_result_3d=-3_c_double
-  type(c_ptr) :: MUI_COMM_WORLD
+  integer(c_int) :: MUI_COMM_WORLD
   integer(kind=8) :: i
 
   !Read in URI from command line


### PR DESCRIPTION
Update the Fortran communicator so that native Fortran MPI functions can use the communicator directly