### PR TITLE
Fix towards integrating MUI into ESI-OpenFOAM

### DIFF
--- a/src/samplers/spatial/sampler_rbf.h
+++ b/src/samplers/spatial/sampler_rbf.h
@@ -187,13 +187,13 @@ public:
       // RBF matrix not yet created
       if (!initialised_) {
           if (generateMatrix_) { // Generating the matrix
-              const clock_t begin_time = clock();
+              const clock_t begin_time = std::clock();
               facilitateGhostPoints();
               REAL error = computeRBFtransformationMatrix(data_points, writeFileAddress_);
 
               if (!QUIET) {
                    std::cout << "MUI [sampler_rbf.h]: Matrices generated in: "
-                             << static_cast<double>(clock() - begin_time) / CLOCKS_PER_SEC << "s ";
+                             << static_cast<double>(std::clock() - begin_time) / CLOCKS_PER_SEC << "s ";
                    if (generateMatrix_) {
                        std::cout << std::endl
                                  << "                     Average CG error: " << error << std::endl;


### PR DESCRIPTION
## The issue
- There is an ambiguity error for the clock() function in the RBF filter (L190 & L196).
- After checking, there is a Foam::clock() function in OpenFOAM.
- In MUI,  clock() defined in ctime header file is used.

## Solution
Adding class name (std) with scope resolution operator for clock() function in RBF to resolve ambiguity when integrating it into ESI-OpenFOAM