### PR TITLE
Updated mpi_split_by_app() - feature OpenFOAM support

### DIFF
--- a/src/communication/lib_mpi_split.h
+++ b/src/communication/lib_mpi_split.h
@@ -58,7 +58,7 @@ namespace mui {
     if (!flag) MPI_Finalize();
   }
 
-  inline MPI_Comm mpi_split_by_app( int argc=0, char **argv=NULL, int threadType=-1, int *thread_support=NULL )
+  inline MPI_Comm mpi_split_by_app( int argc=0, char **argv=NULL, int threadType=-1, int *thread_support=NULL, bool use_mpi_comm_split = true )
   {
     {
     int flag;
@@ -77,13 +77,34 @@ namespace mui {
     int flag;
     MPI_Comm_get_attr(MPI_COMM_WORLD,MPI_APPNUM,&v,&flag);
     if (!flag) {
-    	std::cout << "MUI Info [lib_mpi_split.h]: Calling mpi_split_by_app() when run as a single application" << std::endl;
+        std::cout << "MUI Info [lib_mpi_split.h]: Calling mpi_split_by_app() when run as a single application" << std::endl;
     }
     int appnum = *static_cast<int*>(v);
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD,&rank);
     MPI_Comm domain;
-    MPI_Comm_split(MPI_COMM_WORLD,appnum,rank,&domain);
+    if (use_mpi_comm_split) {
+        MPI_Comm_split(MPI_COMM_WORLD,appnum,rank,&domain);
+    } else {
+        int size;
+        MPI_Comm_size(MPI_COMM_WORLD,&size);
+        std::vector<int> all_appnums(size);
+        all_appnums[rank] = appnum;
+        MPI_Allgather(MPI_IN_PLACE, 0, MPI_INT, all_appnums.data(), 1, MPI_INT, MPI_COMM_WORLD);
+        std::vector<int> group_ranks;
+        for (int i = 0; i < size; ++i) {
+            if (all_appnums[i] == appnum) {
+                group_ranks.push_back(i);
+            }
+        }
+        MPI_Group world_group, new_group;
+        MPI_Comm_group(MPI_COMM_WORLD, &world_group);
+        MPI_Group_incl(world_group, group_ranks.size(), group_ranks.data(), &new_group);
+        MPI_Comm_create_group(MPI_COMM_WORLD, new_group, 0, &domain);
+        MPI_Group_free(&world_group);
+        MPI_Group_free(&new_group);
+    }
+
     return domain;
   }
 }

--- a/wrappers/C/mui_c_wrapper_general.cpp
+++ b/wrappers/C/mui_c_wrapper_general.cpp
@@ -56,8 +56,8 @@ MPI_Comm mui_mpi_split_by_app() {
 }
 
 // Function to split MPI communicator and return new, local communicator using threaded MPI init
-MPI_Comm mui_mpi_split_by_app_threaded(int argc, char **argv, int threadType, int *thread_support) {
-	return mui::mpi_split_by_app(argc, argv, threadType, thread_support);
+MPI_Comm mui_mpi_split_by_app_threaded(int argc, char **argv, int threadType, int *thread_support, int use_mpi_comm_split) {
+	return mui::mpi_split_by_app(argc, argv, threadType, thread_support, static_cast<bool>(use_mpi_comm_split));
 }
 
 }

--- a/wrappers/C/mui_c_wrapper_general.h
+++ b/wrappers/C/mui_c_wrapper_general.h
@@ -52,6 +52,6 @@
 #include "mpi.h"
 
 MPI_Comm mui_mpi_split_by_app();
-MPI_Comm mui_mpi_split_by_app_threaded(int argc, char **argv, int threadType, int *thread_support);
+MPI_Comm mui_mpi_split_by_app_threaded(int argc, char **argv, int threadType, int *thread_support, int use_mpi_comm_split);
 
 #endif /* MUI_C_WRAPPER_GENERAL_H_ */

--- a/wrappers/Fortran/mui_f_wrapper_general.cpp
+++ b/wrappers/Fortran/mui_f_wrapper_general.cpp
@@ -58,8 +58,8 @@ void mui_mpi_split_by_app_f(MPI_Fint *communicator) {
 }
 
 // Function to split MPI communicator and return new, local communicator using threaded MPI init
-void mui_mpi_split_by_app_threaded_f(MPI_Fint *communicator, int *argc, char ***argv, int *threadType, int **thread_support) {
-	*communicator = MPI_Comm_c2f(mui::mpi_split_by_app(*argc, *argv, *threadType, *thread_support));
+void mui_mpi_split_by_app_threaded_f(MPI_Fint *communicator, int *argc, char ***argv, int *threadType, int **thread_support, bool *use_mpi_comm_split) {
+	*communicator = MPI_Comm_c2f(mui::mpi_split_by_app(*argc, *argv, *threadType, *thread_support, *use_mpi_comm_split));
 }
 
 void mui_mpi_get_size_f(MPI_Fint *communicator, int *size) {

--- a/wrappers/Fortran/mui_f_wrapper_general.f90
+++ b/wrappers/Fortran/mui_f_wrapper_general.f90
@@ -60,12 +60,13 @@ module mui_general_f
     end subroutine mui_mpi_split_by_app_f
 
     !Function to split MPI communicator and return new, local communicator
-    subroutine mui_mpi_split_by_app_threaded_f(communicator,argc,argv,threadType,thread_support) bind(C)
-      import :: c_ptr,c_char,c_int
+    subroutine mui_mpi_split_by_app_threaded_f(communicator,argc,argv,threadType,thread_support,use_mpi_comm_split) bind(C)
+      import :: c_ptr,c_char,c_int,c_bool
       type(c_ptr), intent(out), target :: thread_support
       integer(kind=c_int), intent(in), target :: communicator
       integer(kind=c_int), intent(in) :: argc, threadType
       character(kind=c_char), intent(in), dimension(argc) :: argv(*)
+      logical(c_bool), intent(in) :: use_mpi_comm_split
     end subroutine mui_mpi_split_by_app_threaded_f
 
     !Function to get MPI size

--- a/wrappers/Python/mui4py/mui4py.py
+++ b/wrappers/Python/mui4py/mui4py.py
@@ -84,8 +84,10 @@ def get_compiler_config():
     return mui4py_mod.get_compiler_config()
 
 
-def mpi_split_by_app():
-    return mui4py_mod.mpi_split_by_app()
+def mpi_split_by_app(argc=0, argv=None, threadType=-1, thread_support=None, use_mpi_comm_split=True):
+    if argv is None:
+        argv = []
+    return mui4py_mod.mpi_split_by_app(argc, argv, threadType, thread_support, use_mpi_comm_split)
 
 
 def set_quiet(q):


### PR DESCRIPTION
- Adding MPI_Allgather() and MPI_Comm_group() based approach as an alternative of the MPI_Comm_split() approach
- A default bool argument 'use_mpi_comm_split' is used as a switch between these two approaches, with the default behaviour of the MPI_Comm_split() approach
- This update extends compatibility to OpenFOAM-based workflows. Please see details in [OpenFOAM-PR#735](https://develop.openfoam.com/Development/openfoam/-/merge_requests/735) and [OpenFOAM-Issue#3127](https://develop.openfoam.com/Development/openfoam/-/issues/3127)