### PR TITLE
Update minimum CMake version to 3.27

### DIFF
--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.27)
 project(mui4py)
 
 # Set C++ standard before finding pybind11


### PR DESCRIPTION
To use the "CMP0148" policy, the cmake version must be set to 3.27 or later. See [here](https://cmake.org/cmake/help/latest/policy/CMP0148.html) for more details.