### PR TITLE
Added temporal_sampler_linear and corresponding python binding

### DIFF
--- a/src/mui.h
+++ b/src/mui.h
@@ -65,6 +65,7 @@
 #include "samplers/temporal/temporal_sampler_gauss.h"
 #include "samplers/temporal/temporal_sampler_mean.h"
 #include "samplers/temporal/temporal_sampler_sum.h"
+#include "samplers/temporal/temporal_sampler_linear.h"
 
 //Include coupling algorithms
 #include "samplers/algorithm/algo_fixed_relaxation.h"
@@ -119,6 +120,7 @@ namespace mui {
 		DECLARE_SAMPLER_0ARG(temporal_sampler_gauss,SUFFIX,config_##SUFFIX);\
 		DECLARE_SAMPLER_0ARG(temporal_sampler_sum,SUFFIX,config_##SUFFIX);\
 		DECLARE_SAMPLER_0ARG(temporal_sampler_mean,SUFFIX,config_##SUFFIX);\
+		DECLARE_SAMPLER_0ARG(temporal_sampler_linear,SUFFIX,config_##SUFFIX);\
 		DECLARE_SAMPLER_0ARG(algo_fixed_relaxation,SUFFIX,config_##SUFFIX);\
 		DECLARE_SAMPLER_0ARG(algo_aitken,SUFFIX,config_##SUFFIX);\
 		namespace geometry {\
@@ -160,6 +162,7 @@ SPECIALIZE(3fx,float,int64_t,3);
 		DECLARE_SAMPLER_0ARG(temporal_sampler_gauss,SUFFIX,CONFIG);\
 		DECLARE_SAMPLER_0ARG(temporal_sampler_sum,SUFFIX,CONFIG);\
 		DECLARE_SAMPLER_0ARG(temporal_sampler_mean,SUFFIX,CONFIG);\
+		DECLARE_SAMPLER_0ARG(temporal_sampler_linear,SUFFIX,CONFIG);\
 		DECLARE_SAMPLER_0ARG(algo_fixed_relaxation,SUFFIX,CONFIG);\
 		DECLARE_SAMPLER_0ARG(algo_aitken,SUFFIX,CONFIG);\
 		}

--- a/src/samplers/temporal/temporal_sampler_exact.h
+++ b/src/samplers/temporal/temporal_sampler_exact.h
@@ -107,6 +107,11 @@ public:
 		return focus;
 	}
 
+
+	time_type get_barrier_time(time_type focus) const {
+		return get_upper_bound(focus);
+	}
+
 private:
 	time_type tolerance_time;
 	time_type tolerance_it;

--- a/src/samplers/temporal/temporal_sampler_mean.h
+++ b/src/samplers/temporal/temporal_sampler_mean.h
@@ -107,6 +107,11 @@ public:
 		return focus - left_;
 	}
 
+
+	time_type get_barrier_time(time_type focus) const {
+		return get_upper_bound(focus);
+	}
+
 	time_type tolerance() const {
 		return time_type(0);
 	}	

--- a/src/samplers/temporal/temporal_sampler_sum.h
+++ b/src/samplers/temporal/temporal_sampler_sum.h
@@ -101,6 +101,10 @@ public:
 		return focus - left_;
 	}
 
+	time_type get_barrier_time(time_type focus) const {
+		return get_upper_bound(focus);
+	}
+
 	time_type tolerance() const {
 		return time_type(0);
 	}	

--- a/src/uniface.h
+++ b/src/uniface.h
@@ -451,7 +451,7 @@ public:
 		   ADDITIONAL && ... additional ) {
 		// Only enter barrier on first fetch for time=t
 		if( fetch_t_hist_ != t && barrier_enabled )
-			barrier(t_sampler.get_upper_bound(t));
+			barrier(t_sampler.get_barrier_time(t));
 
 		fetch_t_hist_ = t;
 
@@ -464,7 +464,6 @@ public:
 		auto end = log.upper_bound(curr_time_upper);
 
 		if( log.size() == 1 ) end = log.end();
-
 		for( auto start = log.lower_bound(curr_time_lower); start != end; ++start ) {
 			const auto& iter = start->second.find(attr);
 			if( iter == start->second.end() ) continue;
@@ -483,7 +482,7 @@ public:
 		   ADDITIONAL && ... additional ) {
 		// Only enter barrier on first fetch for time=t,iteration=it
 		if((fetch_t_hist_ != t || fetch_i_hist_ != it) && barrier_enabled)
-			barrier(t_sampler.get_upper_bound(t),t_sampler.get_upper_bound(it));
+			barrier(t_sampler.get_barrier_time(t),t_sampler.get_barrier_time(it));
 
 		fetch_t_hist_ = t;
 		fetch_i_hist_ = it;
@@ -516,7 +515,7 @@ public:
 		   bool barrier_enabled = true, ADDITIONAL && ... additional ) {
 		// Only enter barrier on first fetch for time=t
 		if( fetch_t_hist_ != t && barrier_enabled )
-			barrier(t_sampler.get_upper_bound(t));
+			barrier(t_sampler.get_barrier_time(t));
 
 		fetch_t_hist_ = t;
 
@@ -548,7 +547,7 @@ public:
 		   bool barrier_enabled = true, ADDITIONAL && ... additional ) {
 		// Only enter barrier on first fetch for time=t,iteration=it
 		if((fetch_t_hist_ != t || fetch_i_hist_ != it) && barrier_enabled)
-			barrier(t_sampler.get_upper_bound(t),t_sampler.get_upper_bound(it));
+			barrier(t_sampler.get_barrier_time(t),t_sampler.get_barrier_time(it));
 
 		fetch_t_hist_ = t;
 		fetch_i_hist_ = it;
@@ -580,7 +579,7 @@ public:
 				  const TIME_SAMPLER &t_sampler, bool barrier_enabled = true, ADDITIONAL && ... additional ) {
 		// Only enter barrier on first fetch for time=t
 		if( fetch_t_hist_ != t && barrier_enabled )
-			barrier(t_sampler.get_upper_bound(t));
+			barrier(t_sampler.get_barrier_time(t));
 
 		fetch_t_hist_ = t;
 
@@ -617,7 +616,7 @@ public:
 				  const TIME_SAMPLER &t_sampler, bool barrier_enabled = true, ADDITIONAL && ... additional ) {
 		// Only enter barrier on first fetch for time=t,iteration=it
 		if( fetch_t_hist_ != t && fetch_i_hist_ != it && barrier_enabled)
-			barrier(t_sampler.get_upper_bound(t),t_sampler.get_upper_bound(it));
+			barrier(t_sampler.get_barrier_time(t), t_sampler.get_barrier_time(it));
 
 		fetch_t_hist_ = t;
 		fetch_i_hist_ = it;
@@ -656,7 +655,7 @@ public:
 				  const TIME_SAMPLER &t_sampler, bool barrier_enabled = true, ADDITIONAL && ... additional ) {
 		// Only enter barrier on first fetch for time=t,iteration=it
 		if( fetch_t_hist_ != t && barrier_enabled )
-			barrier(t_sampler.get_upper_bound(t));
+			barrier(t_sampler.get_barrier_time(t));
 
 		fetch_t_hist_ = t;
 
@@ -693,7 +692,7 @@ public:
 				  const TIME_SAMPLER &t_sampler, bool barrier_enabled = true, ADDITIONAL && ... additional ) {
 		// Only enter barrier on first fetch for time=t,iteration=it
 		if( fetch_t_hist_ != t && fetch_i_hist_ != it && barrier_enabled)
-			barrier(t_sampler.get_upper_bound(t),t_sampler.get_upper_bound(it));
+			barrier(t_sampler.get_barrier_time(t), t_sampler.get_barrier_time(it));
 
 		fetch_t_hist_ = t;
 		fetch_i_hist_ = it;

--- a/wrappers/Python/mui4py/__init__.py
+++ b/wrappers/Python/mui4py/__init__.py
@@ -54,7 +54,7 @@ from mui4py.samplers import SamplerExact, SamplerGauss, SamplerMovingAverage,\
                             SamplerPseudoNearestNeighbor, SamplerSherpardQuintic,\
                             SamplerSphQuintic, SamplerSumQuintic, SamplerRbf
 from mui4py.temporal_samplers import TemporalSamplerExact, TemporalSamplerGauss,\
-                            TemporalSamplerMean, TemporalSamplerSum
+                            TemporalSamplerMean, TemporalSamplerSum, TemporalSamplerLinear
 from mui4py.algorithms import AlgorithmFixedRelaxation, AlgorithmAitken
 from mui4py.mui_types import STRING, INT32, INT64, INT, UINT32, UINT64, UINT, FLOAT32, FLOAT64, FLOAT, BOOL
 from mui4py.config import Config, set_default_config, get_default_config

--- a/wrappers/Python/mui4py/cpp/temporal_name.h
+++ b/wrappers/Python/mui4py/cpp/temporal_name.h
@@ -55,5 +55,7 @@ std::string temporal_sampler_name()
     return "temporal_sum";
   if (std::is_same<Ttemporal<Tconfig>, mui::temporal_sampler_mean<Tconfig>>::value)
     return "temporal_mean";
+  if (std::is_same<Ttemporal<Tconfig>, mui::temporal_sampler_linear<Tconfig>>::value)
+    return "temporal_linear";
   throw std::runtime_error("Invalid temporal sampler type");
 }

--- a/wrappers/Python/mui4py/cpp/temporal_sampler.cpp
+++ b/wrappers/Python/mui4py/cpp/temporal_sampler.cpp
@@ -76,6 +76,10 @@ void declare_temporal_samplers(py::module &m)
     py::class_<Tclass>(m, name.c_str())
         .def(py::init<Ttime, Ttime>(), py::arg("newleft") = Ttime(0),
              py::arg("newright") = Ttime(0));
+
+    name = "_Temporal_sampler_linear" + config_name<Tconfig>();
+    py::class_<mui::temporal_sampler_linear<Tconfig>>(m, name.c_str())
+        .def(py::init<Ttime>(), py::arg("dtNeighbour") = Ttime(0));
 }
 
 void temporal_sampler(py::module &m)

--- a/wrappers/Python/mui4py/cpp/uniface_base.h
+++ b/wrappers/Python/mui4py/cpp/uniface_base.h
@@ -332,26 +332,32 @@ void declare_uniface_fetch_all_temporal(py::class_<mui::uniface<Tconfig>> &unifa
   declare_uniface_fetch<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
   declare_uniface_fetch<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
   declare_uniface_fetch<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
+  declare_uniface_fetch<Tconfig, T, Tsampler, mui::temporal_sampler_linear>(uniface);
 
   declare_uniface_fetch_dual<Tconfig, T, Tsampler, mui::temporal_sampler_exact>(uniface);
   declare_uniface_fetch_dual<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
   declare_uniface_fetch_dual<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
   declare_uniface_fetch_dual<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
+  declare_uniface_fetch_dual<Tconfig, T, Tsampler, mui::temporal_sampler_linear>(uniface);
 
   declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_exact>(uniface);
   declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
   declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
   declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
+  declare_uniface_fetch_many<Tconfig, T, Tsampler, mui::temporal_sampler_linear>(uniface);
 
   declare_uniface_fetch_many_dual<Tconfig, T, Tsampler, mui::temporal_sampler_exact>(uniface);
   declare_uniface_fetch_many_dual<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
   declare_uniface_fetch_many_dual<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
   declare_uniface_fetch_many_dual<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
+  declare_uniface_fetch_many_dual<Tconfig, T, Tsampler, mui::temporal_sampler_linear>(uniface);
+  
 
   declare_uniface_fetch_all_algorithm<Tconfig, T, Tsampler, mui::temporal_sampler_exact>(uniface);
   declare_uniface_fetch_all_algorithm<Tconfig, T, Tsampler, mui::temporal_sampler_gauss>(uniface);
   declare_uniface_fetch_all_algorithm<Tconfig, T, Tsampler, mui::temporal_sampler_mean>(uniface);
   declare_uniface_fetch_all_algorithm<Tconfig, T, Tsampler, mui::temporal_sampler_sum>(uniface);
+  declare_uniface_fetch_all_algorithm<Tconfig, T, Tsampler, mui::temporal_sampler_linear>(uniface);
 }
 
 template <typename Tconfig, typename T>
@@ -362,21 +368,25 @@ void declare_uniface_fetch_points_values_temporal(py::class_<mui::uniface<Tconfi
   declare_uniface_fetch_points<Tconfig, T, mui::temporal_sampler_gauss>(uniface);
   declare_uniface_fetch_points<Tconfig, T, mui::temporal_sampler_mean>(uniface);
   declare_uniface_fetch_points<Tconfig, T, mui::temporal_sampler_sum>(uniface);
+  declare_uniface_fetch_points<Tconfig, T, mui::temporal_sampler_linear>(uniface);
 
   declare_uniface_fetch_points_dual<Tconfig, T, mui::temporal_sampler_exact>(uniface);
   declare_uniface_fetch_points_dual<Tconfig, T, mui::temporal_sampler_gauss>(uniface);
   declare_uniface_fetch_points_dual<Tconfig, T, mui::temporal_sampler_mean>(uniface);
   declare_uniface_fetch_points_dual<Tconfig, T, mui::temporal_sampler_sum>(uniface);
+  declare_uniface_fetch_points_dual<Tconfig, T, mui::temporal_sampler_linear>(uniface);
 
   declare_uniface_fetch_values<Tconfig, T, mui::temporal_sampler_exact>(uniface);
   declare_uniface_fetch_values<Tconfig, T, mui::temporal_sampler_gauss>(uniface);
   declare_uniface_fetch_values<Tconfig, T, mui::temporal_sampler_mean>(uniface);
   declare_uniface_fetch_values<Tconfig, T, mui::temporal_sampler_sum>(uniface);
+  declare_uniface_fetch_values<Tconfig, T, mui::temporal_sampler_linear>(uniface);
 
   declare_uniface_fetch_values_dual<Tconfig, T, mui::temporal_sampler_exact>(uniface);
   declare_uniface_fetch_values_dual<Tconfig, T, mui::temporal_sampler_gauss>(uniface);
   declare_uniface_fetch_values_dual<Tconfig, T, mui::temporal_sampler_mean>(uniface);
   declare_uniface_fetch_values_dual<Tconfig, T, mui::temporal_sampler_sum>(uniface);
+  declare_uniface_fetch_values_dual<Tconfig, T, mui::temporal_sampler_linear>(uniface);
 }
 
 template <typename Tconfig, typename T>

--- a/wrappers/Python/mui4py/temporal_samplers.py
+++ b/wrappers/Python/mui4py/temporal_samplers.py
@@ -87,3 +87,8 @@ class TemporalSamplerSum(TemporalSampler):
     def __init__(self, newleft=None, newright=None):
         super(TemporalSamplerSum, self).__init__(kwargs={"newleft": newleft, "newright": newright})
         self._ALLOWED_IO_TYPES = [UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]
+
+class TemporalSamplerLinear(TemporalSampler):
+    def __init__(self, dtNeighbour=0):
+        super(TemporalSamplerLinear, self).__init__(kwargs={"dtNeighbour": dtNeighbour})
+        self._ALLOWED_IO_TYPES = [UINT, UINT32, UINT64, INT, INT32, INT64, FLOAT, FLOAT32, FLOAT64]


### PR DESCRIPTION
This Pull request adds a new temporal sampler, temporal_sampler_linear, that assumes a linear rate of change based on the two nearest dataframes and interpolates the value at the requested time accordingly. This has been very useful in our work in the HASTA project for temperature coupling.

To integrate this feature we have added a get_barrier_time() function to the existing temporal samplers, this is motivated by the fact that temporal_sampler_linear needs to have a barrier time equal to focus (since this means the next closest dataframe equal to or after focus must exist) and  upper_bound greater than focus in order to find the next dataframe in the search radius. The maximum search radius can be specified as a user parameter, but by default the entire log is searched. Note that for the existing temporal_samplers no functionality has changed.

This pull request also updates the python bindings to include TemporalSamplerLinear(). C and Fortran bindings still need to be included.

I do not anticipate this sampler breaking any existing MUI functionality, however the new sampler is still under development. As such as I suggest that this feature could be merged into a separate "development " branch allowing us to easily use it in our work while ironing out any bugs. I cannot create such a branch but if one is made I can create a new pull request to target it. Alternatively, it can be merged to the main repository without compromising the current functionality.